### PR TITLE
Implement F-0006 Tool execution boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 > [!IMPORTANT]
 > BearAgent 当前还不能执行真实 Agent 任务。仓库已经实现内部数据类型、Run/Activity 状态、Event
-> Reducer、预算检查、SQLite EventStore、首个 OpenAI Responses adapter 和本地文档站；文件工具、
+> Reducer、预算检查、SQLite EventStore、首个 OpenAI Responses adapter、统一 Tool 执行边界和本地文档站；文件工具、
 > ContextBuilder、完整 Agent Loop 与 Run CLI 仍在 P1 计划中。
 
 ## 从一个文件任务说起
@@ -46,12 +46,13 @@ BearAgent 不以复刻 Manus、Claude Code 或堆叠模型、工具和 Agent 角
 
 | 已有代码 | P1 还要接通 | 更晚再做 |
 |---|---|---|
-| Python 3.12 + uv 工程与 CI | Tool 接口、Registry 与统一 executor | P2：崩溃恢复、Attempt、`UNKNOWN` |
+| Python 3.12 + uv 工程与 CI | 工作区读取、搜索与 `outputs/**` 写入 | P2：崩溃恢复、Attempt、`UNKNOWN` |
 | `help`、`version`、`doctor` | 工作区读取、搜索与 `outputs/**` 写入 | P3：Approval、隔离执行、安全自托管 |
 | 类型化 ID、Message、Error、Event | `outputs/**` 原子写入与 Artifact | P4：Skill、MCP、Web、Memory |
 | Run/Activity 状态与五类预算 | ContextBuilder 与有界 Agent Loop | P5：持续追踪与跨版本评测 |
 | SQLite EventStore、projection 与 migration | `run`、`inspect`、`events` | P6+：多个 Agent、浏览器、分布式执行 |
 | ModelProvider port 与 OpenAI Responses adapter | 固定任务集与可复现结果 | 只有真实需求出现后再扩展 |
+| Tool Registry、固定 Policy 与统一 Executor | 具体文件 Tool 与 Agent Loop 接线 | 只有真实需求出现后再扩展 |
 | 中文 Starlight 文档站 | 端到端固定任务集 | 只有真实需求出现后再扩展 |
 
 当前事实见[路线图](docs/project/roadmap.md)和[公开状态页](site/src/content/docs/zh-cn/project/status.md)。

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,8 +1,8 @@
 ---
 title: BearAgent Architecture Baseline
 status: accepted
-version: 0.4
-last_verified: 2026-08-13
+version: 0.5
+last_verified: 2026-08-14
 ---
 
 # BearAgent 总体架构
@@ -48,16 +48,17 @@ flowchart TB
 | 状态规则 | P1 Run/Activity 状态、12 种具体 Event、纯 Reducer 和五类预算检查 |
 | 持久事实 | EventStore port、SQLite WAL、显式 migration、Run/Activity projection 和事务回滚 |
 | 模型边界 | ModelProvider port、确定性测试 adapter 和首个 OpenAI Responses 流式 adapter |
+| Tool 执行边界 | 有界 Tool 数据、精确 Registry、默认拒绝 Policy 和统一 ToolExecutor |
 | 测试替身 | Fake model、Fake tool、内存 Event store |
 | 文档 | 工程 `docs/` 与本地 Starlight 学习/开发者站点 |
 
-当前可以把 Event 原子写入 SQLite 并查询 projection，也可以通过独立 adapter 调用 OpenAI Responses
-流式接口；两者尚未由 Agent Loop 接成一次用户可运行的文件任务。持久事实仍不等于进程重启后会
-自动继续。
+当前可以把 Event 原子写入 SQLite 并查询 projection，可以通过独立 adapter 调用 OpenAI Responses
+流式接口，也可以让测试 Tool 经过 Registry、Policy 和 Executor。三条边界尚未由 Agent Loop 接成
+一次用户可运行的文件任务。持久事实仍不等于进程重启后会自动继续。
 
 ### 3.2 已接受但尚未接通
 
-- P1：文件工具、统一 Tool executor、ContextBuilder、有界 Agent Loop 和 Run CLI；
+- P1：具体文件工具、ContextBuilder、有界 Agent Loop 和 Run CLI；
 - P2：Checkpoint、Attempt、暂停/继续/取消、恢复协调和 `UNKNOWN` 处置；
 - P3：Grant、Policy、Approval、隔离 runner、HTTP API、认证和备份恢复；
 - P4：Skill、MCP、Web UI、Memory 和受控联网；
@@ -240,18 +241,24 @@ SDK 自动重试被禁用，工具调用参数必须是有界 JSON object，流�
 
 ### 10.1 统一 Tool 路径
 
-每个 Tool 声明输入/输出 schema、副作用类别、所需 Grant、timeout、输出上限和重试方式。`ToolResult`
-返回结构化状态、内容、Artifact、Receipt、耗时和安全 Error，不只返回任意字符串。
+F-0006 已建立统一入口，但还没有注册真实文件 Tool。每个 Tool 先用 `ToolSpec` 声明输入/输出 schema、
+副作用类别、timeout、输出上限和未来能否安全重试。`ToolResult` 返回结构化 JSON 或安全 Error，
+不只返回任意字符串。
 
 ```text
 模型提出 ToolRequest
-  -> Runtime 规范化路径和参数
-  -> Policy 返回 ALLOW / ASK / DENY
-  -> ToolExecutor 执行
-  -> Event 记录结果
+  -> Registry 精确查找 Tool
+  -> Tool.prepare 校验并规范化参数
+  -> P1 Policy 返回 ALLOW / DENY
+  -> ToolExecutor 限时执行并检查结果大小
 ```
 
-所有外部副作用都走这条路径，adapter 不能绕过。
+Registry 拒绝重名和模糊匹配。P1 Policy 默认拒绝，只允许程序启动时列出的名称，并且始终拒绝
+外部写入和代码执行。timeout、异常和超大结果会变成不同的安全 Error；Executor 不自动重试。
+`CancelledError` 原样传播。
+
+F-0016 接入 Agent Loop 时负责把请求、Policy 决定和执行结果写成 Event。F-0007/F-0008 的具体文件
+Tool 必须通过这条路径注册，不能另开旁路。P3 再加入 Grant、`ASK` 和 Approval。
 
 ### 10.2 P1 文件范围
 

--- a/docs/plans/PLAN-F-0006-tool-registry-executor-policy.md
+++ b/docs/plans/PLAN-F-0006-tool-registry-executor-policy.md
@@ -1,0 +1,119 @@
+---
+title: "Implementation Plan: Unified Tool registry, executor, and fixed P1 policy"
+status: completed
+plan_id: PLAN-F-0006
+related_spec: F-0006
+created: 2026-08-13
+last_updated: 2026-08-14
+---
+
+# PLAN-F-0006：统一 Tool Registry、Executor 和 P1 固定 Policy
+
+关联 Spec：`docs/specs/F-0006-tool-registry-executor-policy.md`
+
+## 开始前确认
+
+- 项目所有者已于 2026-08-14 接受 F-0006 Spec；
+- 已有 ADR 已经确定三条边界：模型不能给自己授权、不能在宿主 Runtime 执行 shell、核心模块只交换
+  BearAgent 数据；
+- 仓库目前没有其他 `active` Plan；
+- 当前分支是 `codex/F-0006-tool-executor-policy`，从 `main@8ac43f1` 创建。
+
+## 实施步骤
+
+### 第 1 步：先定义门口收什么、返回什么
+
+Status：completed。
+
+完成后，代码会明确回答：一个 Tool 怎样介绍自己，一次请求包含什么，一次成功或失败怎样返回。
+
+- 修改 `domain/tools.py` 和 `domain/errors.py`，让名称、参数、timeout、结果大小和错误都有明确限制；
+- 修改 `ports/tools.py`，增加“先检查参数，再执行”的接口；
+- 新增 `ports/policy.py`，只规定 Policy 怎样返回允许或拒绝；
+- 把新类型加入公共 Schema；
+- 测试非法输入、深层数据、事后修改、成功/失败互斥和错误信息安全。
+
+完成标志：Tool 数据测试和公共 Schema 测试通过。此时还不会执行任何真实 Tool。
+
+验证：`uv run pytest tests/unit/test_tool_contracts.py tests/contract/test_domain_schemas.py`
+
+### 第 2 步：建立名单和权限门
+
+Status：completed。
+
+完成后，Runtime 能精确找到已注册 Tool，并能在执行前作出固定的允许或拒绝决定。
+
+- 新增 `runtime/tool_registry.py`：拒绝重名，按名称稳定排序，只做精确查找；
+- 新增 `runtime/policy.py`：默认拒绝，只允许程序启动时给出的名称；
+- 即使名称在允许名单里，P1 也拒绝外部写入和代码执行；
+- 测试外部代码事后修改名单、模型参数伪造权限和危险类别绕过。
+
+完成标志：Registry 单元测试和 Policy 安全测试通过。此时仍未调用 Tool。
+
+验证：`uv run pytest tests/unit/test_tool_registry.py tests/security/test_tool_policy.py`
+
+### 第 3 步：把检查、权限和执行串起来
+
+Status：completed。
+
+完成后，一次请求会真正走完 `查名单 -> 检查参数 -> 检查权限 -> 限时执行`。
+
+- 新增 `runtime/tool_executor.py`；
+- 升级测试 Tool，使它能记录每一步是否被调用，并模拟成功、失败、timeout、异常和超大结果；
+- 参数错误或权限拒绝时，测试确认执行方法从未运行；
+- Tool 已开始后，测试确认每个请求最多调用一次，取消不会被包装成普通失败；
+- 任何错误都只能返回有限、安全的信息。
+
+完成标志：Tool 共用接口、Executor 集成测试和安全测试通过。F-0007/F-0008 以后只能通过这个入口
+接入真实文件 Tool。
+
+验证：`uv run pytest tests/contract/test_tool_contract.py tests/integration/test_tool_executor.py tests/security/test_tool_executor.py`
+
+### 第 4 步：让读者能看懂已经完成了什么
+
+Status：completed。
+
+- 在站点初学者页用一次 Tool 请求讲清四个步骤；
+- 在开发者页标出代码入口和最有用的测试；
+- 更新架构、Roadmap 和当前状态；
+- 明确写出“已有统一 Tool 路径，但还没有真实文件 Tool、Agent Loop、CLI 或恢复”；
+- 运行完整测试、文档链接检查、站点构建和安装包检查。
+
+完成标志：代码、测试、`docs/` 和站点说的是同一件事，Spec 变为 `implemented`，Plan 变为
+`completed`。
+
+验证：运行本 Plan 末尾列出的完整命令。
+
+## 每一步都要检查
+
+- [x] 没有绕过 Policy 的执行路径；
+- [x] 参数在权限判断前已经检查和规范化；
+- [x] timeout、取消、输入/输出上限和单次调用规则有测试；
+- [x] 错误没有泄漏原始异常、密钥或完整输出；
+- [x] 没有修改 SQLite 或 v1 Event；
+- [x] 工程文档、初学者页、开发者页和当前状态同步。
+
+## 最终验证
+
+```powershell
+$env:UV_CACHE_DIR = 'D:\BearAgent\.uv-cache'
+uv lock --check
+uv run ruff check src tests scripts/check_docs.py
+uv run ruff format --check src tests scripts/check_docs.py
+uv run pyright src tests scripts/check_docs.py
+uv run pytest --basetemp D:\BearAgent\.test-tmp\pytest
+uv run python scripts/check_docs.py
+npm.cmd run build --prefix=site
+uv build
+git diff --check
+```
+
+命令没有实际通过前，不得把 Plan 标记为 `completed`，也不得把 Spec 标记为 `implemented`。
+
+2026-08-14 实际结果：`uv lock --check`、Ruff、Pyright、160 项 pytest、63 个 Markdown 文件链接、
+Starlight 26 页构建、sdist/wheel 构建、wheel 新公开类型导入和 `git diff --check` 全部通过。站点构建
+仍显示既有的 chunk size、缺少 `site` 配置和 `Entry docs -> 404` 警告，但命令成功退出，F-0006
+没有新增部署入口。
+
+当前限制：Registry、固定 Policy 和 Executor 已实现，但没有真实文件 Tool、Agent Loop、Tool Event
+接线或 CLI Run；这些仍属于 F-0007、F-0008、F-0016 和 F-0005。

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -18,7 +18,7 @@ Plan 不重复 Spec 的需求，也不代替 ADR。开始前确认 Spec 已 `acc
 
 ## 当前计划
 
-没有 active Plan。下一个 P1 Runtime Feature 需要项目所有者确认后再开始。
+没有 active Plan。下一个 P1 Feature 需要项目所有者确认后再开始。
 
 ## 已完成计划
 
@@ -26,4 +26,5 @@ Plan 不重复 Spec 的需求，也不代替 ADR。开始前确认 Spec 已 `acc
 - [PLAN-F-0002：Run/Activity 状态和预算](PLAN-F-0002-run-reducer-activity-lifecycle-budgets.md)
 - [PLAN-F-0003：EventStore、SQLite 和 projection](PLAN-F-0003-event-store-sqlite-projections.md)
 - [PLAN-F-0004：ModelProvider 和首个生产 adapter](PLAN-F-0004-model-provider-first-adapter.md)
+- [PLAN-F-0006：统一 Tool Registry、Executor 和 P1 固定 Policy](PLAN-F-0006-tool-registry-executor-policy.md)
 - [PLAN-F-0015：本地 Starlight 文档站](PLAN-F-0015-local-starlight-docs-site.md)

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -1,8 +1,8 @@
 ---
 title: BearAgent Roadmap
 status: accepted
-version: 0.6
-last_verified: 2026-08-13
+version: 0.7
+last_verified: 2026-08-14
 ---
 
 # BearAgent 项目路线图
@@ -124,6 +124,9 @@ adapter。它还没有被 ContextBuilder、Agent Loop 或 CLI 调用，因此不
 
 P1 的 Policy 是固定允许/拒绝规则。用户 Approval 属于 P3。
 
+F-0006 已完成有界 Tool 数据、精确 Registry、默认拒绝 Policy 和统一 ToolExecutor。当前还没有实际
+文件 Tool，也没有 Agent Loop 把 Tool 请求或结果写成 Event。
+
 #### CLI 和固定任务
 
 - `bearagent run` 启动 Run，并输出模型文本、Tool 状态和最终 Artifact；
@@ -145,7 +148,7 @@ P1 的 Policy 是固定允许/拒绝规则。用户 Approval 属于 P3。
 1. F-0002：Run/Activity 状态、Reducer 和预算——已实现；
 2. F-0003：Event store、SQLite、projection 和 migration——已实现；
 3. F-0004：模型接口和首个真实 adapter——已实现；
-4. F-0006：Tool 接口、Registry、executor 和固定 Policy；
+4. F-0006：Tool 接口、Registry、executor 和固定 Policy——已实现；
 5. F-0007：workspace 边界和只读工具；
 6. F-0008：`outputs/**` 原子写和 Artifact；
 7. F-0016：ContextBuilder、有界 Loop、版本化 Agent 配置和任务集；
@@ -333,7 +336,7 @@ Feature ID 在全项目稳定。未创建 Spec 的名称只表示计划范围；
 1. [F-0001：内部 ID、Message 和 Error](../specs/F-0001-domain-ids-messages-errors.md) — implemented
 2. [F-0002：Run/Activity 状态和预算](../specs/F-0002-run-reducer-activity-lifecycle-budgets.md) — implemented
 3. [F-0003：Event store、SQLite、projection 和 migration](../specs/F-0003-event-store-sqlite-projections.md) — implemented
-4. F-0006：Tool 接口、Registry、executor 和固定 Policy
+4. [F-0006：Tool 接口、Registry、executor 和固定 Policy](../specs/F-0006-tool-registry-executor-policy.md) — implemented
 5. F-0007：workspace 边界和只读工具
 6. F-0008：原子写和 Artifact
 7. [F-0004：模型接口和首个真实 adapter](../specs/F-0004-model-provider-first-adapter.md) — implemented

--- a/docs/specs/F-0006-tool-registry-executor-policy.md
+++ b/docs/specs/F-0006-tool-registry-executor-policy.md
@@ -1,0 +1,234 @@
+---
+title: "Feature: Unified Tool registry, executor, and fixed P1 policy"
+status: implemented
+spec_id: F-0006
+milestone: P1
+owner: CherryYang05
+created: 2026-08-13
+last_updated: 2026-08-14
+implemented_in: "codex/F-0006-tool-executor-policy"
+related_adrs:
+  - ADR-0004
+  - ADR-0005
+  - ADR-0007
+  - ADR-0009
+---
+
+# F-0006：所有 Tool 请求经过同一个执行和权限入口
+
+## 1. 为什么现在要做
+
+假设模型说：“请用 `workspace.read` 读取 `docs/index.md`。”现在 BearAgent 已经能收到这个 Tool 名称和
+参数，但还没有一扇统一的执行入口。调用代码可以直接找到一个 Tool 并运行，也就没有一个固定位置
+回答下面四个问题：
+
+1. 这个 Tool 真的存在吗？
+2. 参数合法吗，路径是否已经整理成唯一形式？
+3. 当前 Runtime 允许它执行吗？
+4. 如果它卡住、报错或返回几百 MB 内容，怎样安全结束？
+
+F-0006 先把这扇门建起来。它暂时不提供真实文件 Tool。F-0007 和 F-0008 以后只需要把具体 Tool
+接到这扇门上，不再各写一套权限和超时逻辑。
+
+## 2. 本次交付
+
+- 一份 Tool 名单。`ToolRegistry` 保存已注册 Tool，并按完整名称查找；
+- 一张 Tool 说明卡。`ToolSpec` 写清参数格式、结果格式、副作用、超时和输入/输出上限；
+- 一道固定权限门。P1 `Policy` 默认拒绝，只允许程序启动时明确列出的 Tool；
+- 一个执行入口。`ToolExecutor` 负责检查、授权、限时调用和整理结果；
+- 一组不访问真实文件或网络的测试 Tool，用来稳定复现成功和各种失败。
+
+## 3. 本次不做
+
+- 不读写真实文件。读取和搜索属于 F-0007，写入 `outputs/**` 属于 F-0008；
+- 不接 Agent Loop、Event 或 CLI。它们仍由 F-0016 和 F-0005 完成；
+- 不做用户审批。P1 没有 Grant、`ASK` 或 Approval；
+- 不提供 shell、代码执行、任意网络 Tool、MCP 或自动发现插件；
+- 不自动重试，也不加入 Attempt、Receipt、Checkpoint 或 `UNKNOWN`；
+- 不修改 SQLite，也不改变已经发布的 v1 Run Event 格式。
+
+## 4. 需要先说明的约定
+
+下面几个英文名会直接出现在代码中：
+
+- `ToolRegistry` 是 Tool 名单；
+- `prepare` 是执行前的纯检查。它可以整理参数，但不能读文件、联网或产生其他副作用；
+- `Policy` 是权限门，只回答允许还是拒绝；
+- `ToolExecutor` 是唯一执行入口；
+- `ToolSpec` 是可信 Tool 自带的说明卡，不是模型授予自己的权限。
+
+一次请求只走下面这条短路径：
+
+```text
+模型给出 Tool 名称和 JSON 参数
+  -> Registry 按精确名称查找
+  -> Tool.prepare 只校验并规范化，不产生外部副作用
+  -> Policy 根据可信配置和规范化参数返回 ALLOW 或 DENY
+  -> Executor 在 timeout 和输出上限内调用 Tool.execute
+  -> 返回成功数据或安全 ErrorInfo
+```
+
+P1 的 Policy 只有 `ALLOW` 和 `DENY`。允许名单来自程序启动配置；模型、Prompt、工作区内容和 Tool
+返回值都不能改它。Tool 可以说明未来是否适合重试，但当前 Executor 每个请求最多调用一次。
+
+## 5. 使用场景
+
+### 正常请求
+
+Tool 已注册、在允许名单中，参数也合法。Executor 调用它一次，并把结果和原来的 `ToolCallId`
+放在一起返回。
+
+### 名字不存在或没有权限
+
+Executor 直接返回失败。Tool 的执行方法不会被调用，也不会尝试找“名称相近”的另一个 Tool。
+
+### 路径有多种写法
+
+以后的文件 Tool 会先在 `prepare` 中把路径整理成唯一形式。Policy 看到整理后的路径，再决定是否
+允许。这样不会出现“检查的是一个路径，实际打开的是另一个路径”。
+
+### Tool 卡住或返回太多内容
+
+Executor 到达 timeout 后结束本次调用；结果超过上限时整次调用失败。它不会悄悄截断结构化数据，
+也不会自动再调用一次。
+
+## 6. 必须满足的行为
+
+### 名称和数据要可控
+
+- Tool 名称使用项目已有的统一格式；
+- 参数、说明卡和结果都是大小、嵌套深度和节点数量有限的 JSON object；
+- BearAgent 收到数据后会复制并冻结，外部代码不能事后修改；
+- 请求、规范化请求和结果都带同一个 `ToolCallId`，防止把结果接到错误请求上。
+
+### Registry 只做精确查找
+
+- 启动时发现重名 Tool，Registry 立即失败；
+- Tool 按名称稳定排序，方便测试和生成模型可见的说明；
+- 找不到名称时直接失败，不猜测、不模糊匹配、不调用默认 Tool。
+
+### 先检查参数，再检查权限
+
+- `prepare` 必须先运行，并且不能产生外部副作用；
+- `prepare` 失败后，不再调用 Policy 或 Tool；
+- Policy 只看整理后的参数；
+- Policy 默认拒绝，名称必须出现在可信允许名单中；
+- P1 即使允许了名称，也永远拒绝外部写入和代码执行类别。
+
+### Executor 负责收住失控调用
+
+- 一个请求最多调用 Tool 一次；
+- 每个 Tool 都有有限 timeout，以及最大输入和输出字节数；
+- 调用者主动取消时，取消信号原样向上传递；
+- Tool 抛出的异常只变成安全错误，不包含异常类型、堆栈、密钥或完整输出；
+- 结构化结果超过上限时整次失败，不把半截 JSON 当作成功。
+
+失败原因使用稳定代码：
+
+| 发生了什么 | 返回代码 | Tool 是否执行 |
+|---|---|---|
+| 名称未注册 | `tool_not_found` | 否 |
+| 参数不合法 | `tool_invalid_input` | 否 |
+| Policy 拒绝 | `tool_permission_denied` | 否 |
+| 调用超时 | `tool_timeout` | 已调用一次 |
+| 结果过大 | `tool_output_too_large` | 已调用一次 |
+| Tool 抛出其他异常 | `tool_error` | 已调用一次 |
+
+这些错误在 P1 都不会自动重试。Tool 数据、Policy 结果和错误代码进入公共 JSON Schema。Runtime
+仍然只能依赖 BearAgent 类型和 port，不能导入具体文件 Tool、Provider SDK、CLI 或数据库 adapter。
+
+## 7. 对外入口和模块连接
+
+实现后，代码按职责放在下面几个位置：
+
+| 位置 | 负责什么 |
+|---|---|
+| `domain.tools` | Tool 的说明、请求、结果和权限决定长什么样 |
+| `ports.tools` | 具体 Tool 必须提供 `prepare` 和 `execute` |
+| `ports.policy` | Policy 必须能对规范化请求作出允许或拒绝决定 |
+| `runtime.tool_registry` | 保存和查找已注册 Tool |
+| `runtime.policy` | 实现 P1 固定权限规则 |
+| `runtime.tool_executor` | 串起查找、检查、权限和执行 |
+
+F-0016 以后会把模型给出的 `ModelToolCall` 转成 `ToolRequest`，交给 `ToolExecutor`，再把结果写成
+Tool Activity Event 并交回模型。F-0007/F-0008 负责注册真实文件 Tool。
+
+本 Feature 不增加 CLI/API，也不让 Runtime 直接导入具体 Tool adapter。
+
+## 8. 状态和保存的数据
+
+F-0006 自己不保存数据。Executor 完成一次调用后，只把结果返回给调用方。它不增加 Run 状态、Event、
+SQLite 表或数据库升级脚本。
+
+F-0016 接入 Agent Loop 时，才负责把 Tool 请求、开始和结束写进 Event。现在已经存在的 v1 Tool
+Event 保持原样；以后要保存完整参数和结果时，新增 v2，不能偷偷改变旧 Event 的含义。
+
+## 9. 失败时会发生什么
+
+- 名称不存在、参数不合法或 Policy 拒绝时，Tool 还没开始，因此不会产生外部动作；
+- Tool 超时后，本次调用结束，P1 不会自动再试；
+- Tool 主动报告失败时，Executor 保留经过检查的安全错误；Tool 直接抛异常时，只返回通用错误；
+- 结果太大时整次失败。以后有 Artifact 后，可以另行设计“保存大结果，只返回引用”；
+- 如果进程在 Tool 运行中退出，F-0006 不猜测 Tool 是否已经完成，也不自动继续。P2 再处理恢复和
+  `UNKNOWN`；
+- 用户取消或进程中断永远不会被写成成功。
+
+## 10. 安全与隐私
+
+- 模型给出的名称和参数、Tool 返回的数据，都先当作不可信输入检查；
+- Tool 自己的说明卡来自程序注册，单次请求不能覆盖；
+- 允许名单在程序启动时复制保存。Prompt、Skill、工作区文件和 Tool 返回值都不能修改；
+- Policy 只检查整理后的参数，避免“批准一个写法、执行另一个含义”；
+- 错误里不放密钥、授权头、原始异常、堆栈或完整敏感输出；
+- F-0006 不注册 shell、代码、网络或真实文件 Tool，也不启动宿主机子进程。
+
+## 11. 怎样检查执行过程
+
+调用者可以直接从 `ToolResult` 看出成功还是失败。失败代码能区分名称不存在、参数错误、权限拒绝、
+timeout、结果过大和 Tool 异常，不需要解析一段自由文本。
+
+F-0006 还不写 Event。F-0016 接入时必须把请求、Policy 决定、开始和结束写成连续 Event，之后
+`inspect/events` 才能还原整段过程。
+
+## 12. 上线与回退
+
+这次代码落地后，CLI 行为不会变化，因为还没有真实文件 Tool，也没有 Agent Loop 调用 Executor。
+如果需要回退，可以整体删除新组件并恢复旧测试 Tool；没有数据库或外部数据需要处理。
+
+以后 Tool 数据开始写入 Event 后，再做不兼容修改必须增加版本，不能覆盖旧数据。
+
+## 13. 验收标准
+
+下面八件事全部成立，F-0006 才算完成：
+
+1. 非法名称、未知字段、非 JSON object、过深/过大的数据和非法 timeout 会被拒绝；
+2. Registry 拒绝重名，只做精确查找，并以稳定顺序列出 Tool；
+3. 正常请求严格按 `prepare -> Policy -> execute` 运行，Tool 只执行一次；
+4. 参数错误或权限拒绝时，Tool 没有执行；
+5. 模型和 Tool 返回值都不能扩大允许名单，外部写入和代码执行在 P1 始终被拒绝；
+6. timeout、Tool 主动失败、异常和超大输出得到不同的安全错误，且不泄漏敏感信息；
+7. 调用者取消会原样向上传递，Executor 不会自动重试；
+8. 公共 Schema、架构边界、类型检查、全部测试、文档、站点和安装包验证通过。
+
+## 14. 验证方式
+
+- 单元测试检查数据限制、冻结、Registry 和固定 Policy；
+- 共用接口测试检查 Fake Tool 的 `prepare`、`execute` 和错误规则；
+- 集成测试用内存 Tool 跑完整条路径，不访问真实文件或网络；
+- 安全测试检查默认拒绝、未注册名称、权限篡改和敏感信息泄漏；
+- timeout 和异常测试确认同一请求不会执行第二次；进程恢复仍留到 P2；
+- 本 Feature 没有 Agent Loop 或真实文件任务，因此不做模型效果评测。
+
+## 15. 文档同步
+
+- [x] 更新 Spec、Plan、架构和 ADR 链接；
+- [x] 新增一页初学者说明，用一次 Tool 请求解释 `prepare`、Policy 和执行；
+- [x] 新增开发者导读，标出代码入口和最重要的测试；
+- [x] 更新当前状态，同时写清“还没有真实文件 Tool 和 Agent Loop”；
+- [x] 确认没有部署变化；
+- [x] 更新公共 Tool/Policy Schema 快照。
+
+## 16. 尚未决定的问题
+
+无。项目所有者于 2026-08-14 接受本 Spec：P1 在程序启动时列出允许的 Tool；没有列出的
+一律拒绝；外部写入和代码执行始终拒绝。F-0006 不顺带实现真实文件 Tool、Event v2 或自动重试。

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -24,6 +24,7 @@ draft -> accepted -> implemented -> superseded
 - [F-0002：从 Event 计算 Run/Activity 状态和预算](F-0002-run-reducer-activity-lifecycle-budgets.md) — implemented
 - [F-0003：使用 SQLite 原子保存 Event 和 projection](F-0003-event-store-sqlite-projections.md) — implemented
 - [F-0004：建立模型内部接口和首个生产 adapter](F-0004-model-provider-first-adapter.md) — implemented
+- [F-0006：所有 Tool 请求经过同一个执行和权限入口](F-0006-tool-registry-executor-policy.md) — implemented
 - [F-0015：建立本地中文文档站](F-0015-local-starlight-docs-site.md) — implemented
 
 其余计划 Feature 见[路线图 Backlog](../project/roadmap.md#11-feature-backlog)。未创建 Spec 的名称只是

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -41,6 +41,7 @@ export default defineConfig({
             { label: '逐条读懂一次 Run', slug: 'learn/run-event-reducer-walkthrough' },
             { label: '持久事实与安全恢复', slug: 'learn/durable-events' },
             { label: '为什么模型需要独立边界', slug: 'learn/model-provider-boundary' },
+            { label: 'Tool 请求为什么要过四道检查', slug: 'learn/tool-execution-boundary' },
           ],
         },
         {
@@ -59,6 +60,7 @@ export default defineConfig({
             { label: 'F-0002：修改状态和预算', slug: 'development/run-reducer-and-budgets' },
             { label: 'F-0003：SQLite EventStore', slug: 'development/sqlite-event-store' },
             { label: 'F-0004：ModelProvider', slug: 'development/model-provider' },
+            { label: 'F-0006：Tool 执行边界', slug: 'development/tool-execution-boundary' },
           ],
         },
         {

--- a/site/src/content/docs/zh-cn/architecture/index.md
+++ b/site/src/content/docs/zh-cn/architecture/index.md
@@ -9,15 +9,16 @@ sourceRefs:
   - F-0002
   - F-0003
   - F-0004
+  - F-0006
 ---
 
 模型请求读取 `docs/architecture/overview.md` 时，BearAgent 需要检查路径、调用文件工具、保存结果，
 再把内容交给下一次模型调用。这条路径跨过多个模块，但每个模块只负责其中一段。
 
 :::caution[图中包含尚未实现的连接]
-当前已实现领域类型、Run/Activity 状态、Reducer、预算检查、SQLite EventStore 和首个 OpenAI
-Responses adapter。工具执行、ContextBuilder 和完整 Agent Loop 仍在 P1 计划中；权限审批和隔离
-环境属于 P3。
+当前已实现领域类型、Run/Activity 状态、Reducer、预算检查、SQLite EventStore、首个 OpenAI
+Responses adapter，以及 Registry、固定 Policy 和统一 ToolExecutor。具体文件 Tool、ContextBuilder
+和完整 Agent Loop 仍在 P1 计划中；用户审批和隔离环境属于 P3。
 :::
 
 ```mermaid

--- a/site/src/content/docs/zh-cn/development/index.md
+++ b/site/src/content/docs/zh-cn/development/index.md
@@ -25,6 +25,7 @@ sourceRefs:
 - [F-0002：状态和预算](run-reducer-and-budgets.md)——具体 Event、Reducer、预算检查和修改顺序；
 - [F-0003：SQLite EventStore](sqlite-event-store.md)——transaction、migration、projection 和故障测试；
 - [F-0004：ModelProvider](model-provider.md)——Responses 流式翻译、资源上限和安全错误；
+- [F-0006：Tool 执行边界](tool-execution-boundary.md)——Registry、参数准备、默认拒绝 Policy 和统一 Executor；
 - [Feature 完成时怎样更新文档](feature-documentation.md)——哪些事实写在 `docs/`，哪些解释写在站点；
 - [本地运行文档站](../guides/local-docs.md)——安装、构建和检查 Starlight。
 

--- a/site/src/content/docs/zh-cn/development/tool-execution-boundary.md
+++ b/site/src/content/docs/zh-cn/development/tool-execution-boundary.md
@@ -1,0 +1,61 @@
+---
+title: F-0006 Tool 执行边界实现导读
+description: 从请求数据进入 Registry、Policy 和 Executor，并找到对应测试。
+bearStatus: implemented
+sourceRefs:
+  - F-0006
+  - PLAN-F-0006
+  - ADR-0004
+  - ADR-0005
+---
+
+F-0006 把原来的 P0 FakeTool 占位升级为一条可复用的执行路径。它不实现真实文件访问，也不写 Event。
+阅读代码时，先跟一条请求走完，再看每个类型的细节。
+
+## 请求从哪里经过
+
+```text
+ToolExecutor.execute(request)
+  -> ToolRegistry.get(name)
+  -> Tool.prepare(request)
+  -> ToolPolicy.evaluate(spec, prepared_request)
+  -> Tool.execute(prepared_request)
+  -> ToolResult
+```
+
+前面任一步失败，后面的步骤都不会运行。`tests/integration/test_tool_executor.py` 用会记录调用次数的
+FakeTool 检查了这个顺序。
+
+## 代码地图
+
+| 位置 | 责任 |
+|---|---|
+| `src/bearagent/domain/tools.py` | ToolSpec、请求、结果、Policy 决定和输入/输出资源上限 |
+| `src/bearagent/ports/tools.py` | 具体 Tool 必须实现的 prepare/execute 接口 |
+| `src/bearagent/ports/policy.py` | Policy 接口 |
+| `src/bearagent/runtime/tool_registry.py` | Tool 快照、稳定排序和精确查找 |
+| `src/bearagent/runtime/policy.py` | P1 默认拒绝和危险副作用硬拒绝 |
+| `src/bearagent/runtime/tool_executor.py` | 调用顺序、timeout、取消、输出上限和错误转换 |
+| `src/bearagent/adapters/testing/tools.py` | 不访问外部环境的确定性 FakeTool |
+
+## 修改时先守住三个不变量
+
+第一，`prepare` 必须是纯检查。未来路径规范化可以放这里，实际读取或写入不可以。
+
+第二，Policy 必须看到规范化请求。不要在 Policy 之外复制允许名单，也不要让 Tool 参数覆盖
+`ToolSpec` 的副作用类别。
+
+第三，所有执行都经过 `ToolExecutor`。具体 Tool 不应由 Agent Loop 或 adapter 直接调用，否则 timeout、
+输出上限和默认拒绝会出现旁路。
+
+## 测试从哪里看
+
+- `tests/unit/test_tool_contracts.py`：JSON 边界、深层不可修改和成功/失败结果规则；
+- `tests/unit/test_tool_registry.py`：重名、稳定顺序和精确查找；
+- `tests/security/test_tool_policy.py`：默认拒绝、允许名单快照和危险副作用；
+- `tests/contract/test_tool_contract.py`：FakeTool 的 prepare/execute 共用接口；
+- `tests/integration/test_tool_executor.py`：完整顺序和正常失败；
+- `tests/security/test_tool_executor.py`：timeout、取消、异常、超大输出和敏感信息。
+
+F-0007 接入第一个真实 Tool 时，应让同一组接口和 Executor 测试继续成立。F-0016 接线时，只调用
+`ToolExecutor.execute`，并负责把前后状态写成 Tool Activity Event。

--- a/site/src/content/docs/zh-cn/learn/index.md
+++ b/site/src/content/docs/zh-cn/learn/index.md
@@ -8,6 +8,7 @@ sourceRefs:
   - F-0002
   - F-0003
   - F-0004
+  - F-0006
 ---
 
 这条学习路径始终使用同一个例子：用户要求 Agent 阅读仓库文档，并把总结写进 `outputs/`。
@@ -57,5 +58,11 @@ Event 和 projection，以及为什么数据库能够重开仍不等于 Runtime 
 [为什么模型服务需要独立边界](model-provider-boundary.md)沿着 F-0004 的流式请求说明 SDK 对象、
 Provider tool call ID、usage 和异常怎样被翻译成 BearAgent 内部数据。
 
-当前这条路径覆盖 F-0001 至 F-0004。文件工具、ContextBuilder 和完整 Agent Loop 仍是 P1 的后续
-工作；崩溃恢复和授权分别属于 P2、P3。
+## 7. 看一次 Tool 请求怎样通过检查和权限
+
+[一个 Tool 请求为什么要过四道检查](tool-execution-boundary.md)用读取 `docs/index.md` 的请求解释
+Registry、`prepare`、Policy 和 Executor。你会看到参数错误和权限拒绝为什么必须发生在 Tool 真正
+执行之前。
+
+当前这条路径覆盖已实现的 F-0001 至 F-0004 和 F-0006。具体文件 Tool、ContextBuilder 和完整
+Agent Loop 仍是 P1 的后续工作；崩溃恢复和用户授权分别属于 P2、P3。

--- a/site/src/content/docs/zh-cn/learn/tool-execution-boundary.md
+++ b/site/src/content/docs/zh-cn/learn/tool-execution-boundary.md
@@ -1,0 +1,74 @@
+---
+title: 一个 Tool 请求为什么要过四道检查
+description: 从读取 docs/index.md 的请求理解 Registry、prepare、Policy 和 Executor。
+bearStatus: implemented
+sourceRefs:
+  - F-0006
+  - ADR-0004
+  - ADR-0005
+---
+
+假设模型提出：用 `workspace.read` 读取 `docs/index.md`。模型只是提出请求，它不能因为自己写出了
+这个名称，就获得读文件权限。BearAgent 会让请求依次经过四个位置。
+
+:::caution[当前还没有真实文件 Tool]
+F-0006 已实现下面的名单、参数检查、固定 Policy 和 Executor。F-0007 才会接入目录列出、文件读取和
+搜索；F-0016 才会把它们接进 Agent Loop。
+:::
+
+```mermaid
+flowchart TB
+    A["请求 workspace.read"] --> B["Registry：名单里有吗"]
+    B --> C["prepare：参数是否合法"]
+    C --> D["Policy：当前允许吗"]
+    D --> E["Executor：限时执行"]
+    E --> F["返回结构化结果或安全错误"]
+```
+
+## Registry 只回答“这个 Tool 是否存在”
+
+`ToolRegistry` 是程序启动时建立的 Tool 名单。名称必须完全相同；`workspace.read` 不会匹配
+`Workspace.Read`，也不会因为只写了 `workspace` 就猜一个默认 Tool。名单中出现重名时，程序直接
+拒绝启动这组 Tool。
+
+这样做的原因很实际：模型拼错名字时，应当得到“Tool 不存在”，而不是意外运行另一个动作。
+
+## prepare 先把参数整理清楚
+
+每个 Tool 的 `prepare` 负责检查自己的参数，并把等价写法整理成一种形式。以后文件 Tool 可以在
+这里把 `docs/./index.md` 整理为 `docs/index.md`。
+
+`prepare` 不能读文件、联网或写数据库。它只处理数据。参数不合法时，请求在这里结束，Policy 和
+真正的执行方法都不会运行。
+
+## Policy 独立决定是否允许
+
+P1 的 Policy 很小：默认拒绝，只允许程序启动时明确列出的 Tool。模型参数、Prompt、工作区文件和
+Tool 返回值都不能修改这份名单。
+
+Policy 看到的是 `prepare` 整理后的参数。因此不会出现“权限检查时是一个路径，真正执行时变成另一个
+路径”。P1 还会始终拒绝外部写入和代码执行。可配置 Grant 和用户 Approval 属于 P3。
+
+## Executor 收住 timeout、异常和大结果
+
+只有通过前三步的请求才会进入 `ToolExecutor`。Executor 对一次请求最多调用 Tool 一次，并使用
+`ToolSpec` 中的 timeout、输入字节上限和输出字节上限。
+
+| 发生了什么 | 用户能看到什么 |
+|---|---|
+| 名称不存在 | `tool_not_found`，Tool 未执行 |
+| 参数错误 | `tool_invalid_input`，Tool 未执行 |
+| Policy 拒绝 | `tool_permission_denied`，Tool 未执行 |
+| Tool 超时 | `tool_timeout`，不自动重试 |
+| 结果太大 | `tool_output_too_large`，不返回半截 JSON |
+| Tool 抛出异常 | `tool_error`，不暴露原始异常和密钥 |
+
+调用者主动取消时，取消信号会原样向上传递，不会被伪装成普通 Tool 失败。
+
+## 这还不是完整文件任务
+
+F-0006 只建好了统一入口。现在没有 Tool 会真的打开 `docs/index.md`，也没有 Agent Loop 调用
+Executor，更没有 CLI 展示 Tool Activity。接下来 F-0007/F-0008 接入受限文件 Tool，F-0016 再把
+请求和结果写成 Event。
+
+想看实现位置，可以继续阅读 [F-0006 Tool 执行边界实现导读](../development/tool-execution-boundary.md)。

--- a/site/src/content/docs/zh-cn/project/milestones.md
+++ b/site/src/content/docs/zh-cn/project/milestones.md
@@ -30,8 +30,9 @@ P1 要接通 SQLite、一个真实模型、受限文件工具、有结束条件�
 `events` 命令。写入范围固定为 `outputs/**`。完成时，固定测试模型必须完成全部 5 个任务，真实
 模型在固定配置下至少完成 4 个，并且非法路径和预算耗尽都有清楚的失败记录。
 
-当前已经完成 SQLite EventStore 和首个 OpenAI Responses adapter；它们仍是两个独立边界。受限
-文件工具、ContextBuilder、Agent Loop 和 Run CLI 接通后，才会形成阶段要求的用户结果。
+当前已经完成 SQLite EventStore、首个 OpenAI Responses adapter，以及 Registry、固定 Policy 和
+统一 ToolExecutor；它们仍未由 Agent Loop 接成一次 Run。受限文件工具、ContextBuilder、Agent Loop
+和 Run CLI 接通后，才会形成阶段要求的用户结果。
 
 P1 只保证已经保存的事实可以查看。进程退出后不会自动继续。
 

--- a/site/src/content/docs/zh-cn/project/status.md
+++ b/site/src/content/docs/zh-cn/project/status.md
@@ -8,6 +8,7 @@ sourceRefs:
   - F-0002
   - F-0003
   - F-0004
+  - F-0006
   - F-0015
 ---
 
@@ -23,24 +24,24 @@ BearAgent 当前还不能调用真实模型完成文件任务。已经写入路�
 | F-0002 状态和预算规则 | 12 种 Event 可以推导 Run/Activity 状态；五类预算在新 Activity 前检查 |
 | F-0003 SQLite EventStore | Event 与 Run/Activity projection 原子提交；migration、重开、并发和损坏读取有测试 |
 | F-0004 模型边界 | Provider-neutral 请求/事件、确定性 adapter 和 OpenAI Responses 流式 adapter |
+| F-0006 Tool 执行边界 | 有界 Tool 数据、精确 Registry、默认拒绝 Policy、统一 Executor 和安全失败 |
 | F-0015 本地文档站 | 中文 Starlight 页面、搜索和 Mermaid 可以在本地构建 |
 
 ## P1 还需要接通
 
-- 工具接口、统一执行入口和固定权限规则；
-- 工作区读取、搜索和 `outputs/**` 原子写入；
+- 工作区读取、搜索和 `outputs/**` 原子写入，并接入现有 ToolExecutor；
 - 最小上下文组装和有界 Agent Loop；
 - `run`、`inspect`、`events` 命令以及固定评测任务。
 
-这些工作在 Roadmap 中有稳定 Feature ID，但未创建 Spec 的条目仍只是待办。仓库当前没有 active Plan，
-下一个 P1 Feature 需要由项目所有者确认后开始。
+这些工作在 Roadmap 中有稳定 Feature ID，但未创建 Spec 的条目仍只是待办。仓库当前没有 active
+Plan；下一个 P1 Feature 需要由项目所有者确认后开始。
 
 ## 当前明确不能做
 
 - 不能从 CLI 启动一次真实模型文件任务或执行完整 Agent Loop；
 - SQLite 可以保存 Event 和 projection，但进程重启后不会自动继续 Run；
 - 模型 adapter 可以翻译一次 Responses 流，但尚未由 ContextBuilder 或 Runtime 调度；
-- 没有实际文件工具、用户 Approval、sandbox 或服务器 API；
+- 有统一 Tool 执行入口，但没有实际文件 Tool、用户 Approval、sandbox 或服务器 API；
 - 文档站只在本地和 CI 构建，尚未发布到 `docs.bearguin.cn`。
 
 F-0002 的确定性重放只说明“同一串 Event 会算出同一状态”。它不是 P2 的崩溃恢复，也没有

--- a/src/bearagent/adapters/testing/tools.py
+++ b/src/bearagent/adapters/testing/tools.py
@@ -1,18 +1,79 @@
-"""Deterministic tool adapter for runtime tests."""
+"""Deterministic Tool adapter for runtime tests."""
 
-from bearagent.domain.tools import ToolRequest, ToolResult
+import asyncio
+from collections.abc import Mapping
+
+from pydantic import JsonValue
+
+from bearagent.domain.errors import ErrorInfo
+from bearagent.domain.tools import (
+    PreparedToolRequest,
+    ToolRequest,
+    ToolResult,
+    ToolSpec,
+    ToolStatus,
+)
 
 
 class FakeTool:
-    """Return a configured result and retain requests for assertions."""
+    """Record each stage and return one configured result without external I/O."""
 
-    def __init__(self, name: str, result: ToolResult) -> None:
-        if not name:
-            raise ValueError("name must not be empty")
-        self.name = name
-        self._result = result
-        self.requests: list[ToolRequest] = []
+    def __init__(
+        self,
+        spec: ToolSpec,
+        *,
+        data: Mapping[str, JsonValue] | None = None,
+        failure: ErrorInfo | None = None,
+        prepared_arguments: Mapping[str, JsonValue] | None = None,
+        prepare_error: Exception | None = None,
+        execute_error: Exception | None = None,
+        delay_seconds: float = 0,
+    ) -> None:
+        if data is not None and failure is not None:
+            raise ValueError("FakeTool cannot configure both data and failure")
+        if delay_seconds < 0:
+            raise ValueError("delay_seconds must not be negative")
+        self.spec = spec
+        self._data = {} if data is None else dict(data)
+        self._failure = failure
+        self._prepared_arguments = None if prepared_arguments is None else dict(prepared_arguments)
+        self._prepare_error = prepare_error
+        self._execute_error = execute_error
+        self._delay_seconds = delay_seconds
+        self.prepare_requests: list[ToolRequest] = []
+        self.requests: list[PreparedToolRequest] = []
 
-    async def execute(self, request: ToolRequest) -> ToolResult:
+    def prepare(self, request: ToolRequest) -> PreparedToolRequest:
+        """Record and normalize one request without external I/O."""
+        self.prepare_requests.append(request)
+        if self._prepare_error is not None:
+            raise self._prepare_error
+        if request.name != self.spec.name:
+            raise ValueError("request name does not match the Tool spec")
+        arguments = (
+            request.arguments if self._prepared_arguments is None else self._prepared_arguments
+        )
+        return PreparedToolRequest(
+            tool_call_id=request.tool_call_id,
+            name=request.name,
+            arguments=arguments,
+        )
+
+    async def execute(self, request: PreparedToolRequest) -> ToolResult:
+        """Return the configured result after an optional deterministic delay."""
         self.requests.append(request)
-        return self._result
+        if self._delay_seconds:
+            await asyncio.sleep(self._delay_seconds)
+        if self._execute_error is not None:
+            raise self._execute_error
+        if self._failure is not None:
+            return ToolResult(
+                tool_call_id=request.tool_call_id,
+                status=ToolStatus.FAILED,
+                error=self._failure,
+            )
+        return ToolResult(
+            tool_call_id=request.tool_call_id,
+            status=ToolStatus.SUCCEEDED,
+            data=self._data,
+        )

--- a/src/bearagent/domain/__init__.py
+++ b/src/bearagent/domain/__init__.py
@@ -60,7 +60,18 @@ from bearagent.domain.runs import (
     RunState,
     RunStatus,
 )
-from bearagent.domain.tools import ToolRequest, ToolResult, ToolStatus
+from bearagent.domain.tools import (
+    PolicyDecision,
+    PolicyOutcome,
+    PolicyReason,
+    PreparedToolRequest,
+    ToolRequest,
+    ToolResult,
+    ToolRetrySafety,
+    ToolSideEffect,
+    ToolSpec,
+    ToolStatus,
+)
 
 __all__ = [
     "ActivityId",
@@ -99,6 +110,10 @@ __all__ = [
     "ModelToolDefinition",
     "ModelUsage",
     "OpaqueId",
+    "PolicyDecision",
+    "PolicyOutcome",
+    "PolicyReason",
+    "PreparedToolRequest",
     "RunId",
     "RunCreatedPayload",
     "RunFailedPayload",
@@ -117,6 +132,9 @@ __all__ = [
     "ToolRequest",
     "ToolResult",
     "ToolResultPart",
+    "ToolRetrySafety",
+    "ToolSideEffect",
+    "ToolSpec",
     "ToolStatus",
     "Uuid4IdGenerator",
 ]

--- a/src/bearagent/domain/errors.py
+++ b/src/bearagent/domain/errors.py
@@ -64,6 +64,11 @@ class ErrorCode(StrEnum):
     PROVIDER_INVALID_REQUEST = "provider_invalid_request"
     PROVIDER_REFUSED = "provider_refused"
     PROVIDER_PROTOCOL_ERROR = "provider_protocol_error"
+    TOOL_NOT_FOUND = "tool_not_found"
+    TOOL_INVALID_INPUT = "tool_invalid_input"
+    TOOL_PERMISSION_DENIED = "tool_permission_denied"
+    TOOL_TIMEOUT = "tool_timeout"
+    TOOL_OUTPUT_TOO_LARGE = "tool_output_too_large"
     TOOL_ERROR = "tool_error"
     PERSISTENCE_ERROR = "persistence_error"
     INTERNAL_ERROR = "internal_error"
@@ -83,6 +88,11 @@ _CODE_CATEGORIES = {
     ErrorCode.PROVIDER_INVALID_REQUEST: ErrorCategory.PROVIDER,
     ErrorCode.PROVIDER_REFUSED: ErrorCategory.PROVIDER,
     ErrorCode.PROVIDER_PROTOCOL_ERROR: ErrorCategory.PROVIDER,
+    ErrorCode.TOOL_NOT_FOUND: ErrorCategory.TOOL,
+    ErrorCode.TOOL_INVALID_INPUT: ErrorCategory.TOOL,
+    ErrorCode.TOOL_PERMISSION_DENIED: ErrorCategory.TOOL,
+    ErrorCode.TOOL_TIMEOUT: ErrorCategory.TOOL,
+    ErrorCode.TOOL_OUTPUT_TOO_LARGE: ErrorCategory.TOOL,
     ErrorCode.TOOL_ERROR: ErrorCategory.TOOL,
     ErrorCode.PERSISTENCE_ERROR: ErrorCategory.PERSISTENCE,
     ErrorCode.INTERNAL_ERROR: ErrorCategory.INTERNAL,

--- a/src/bearagent/domain/schema.py
+++ b/src/bearagent/domain/schema.py
@@ -45,6 +45,13 @@ from bearagent.domain.runs import (
     BudgetUsage,
     RunState,
 )
+from bearagent.domain.tools import (
+    PolicyDecision,
+    PreparedToolRequest,
+    ToolRequest,
+    ToolResult,
+    ToolSpec,
+)
 
 PUBLIC_SCHEMA_MODELS: tuple[type[BaseModel], ...] = (
     ActivityId,
@@ -70,6 +77,8 @@ PUBLIC_SCHEMA_MODELS: tuple[type[BaseModel], ...] = (
     ModelToolCall,
     ModelToolDefinition,
     ModelUsage,
+    PolicyDecision,
+    PreparedToolRequest,
     RunId,
     RunCreatedPayload,
     RunFailedPayload,
@@ -82,6 +91,9 @@ PUBLIC_SCHEMA_MODELS: tuple[type[BaseModel], ...] = (
     ToolCallFailedPayload,
     ToolCallRequestedPayload,
     ToolCallStartedPayload,
+    ToolRequest,
+    ToolResult,
+    ToolSpec,
 )
 
 

--- a/src/bearagent/domain/tools.py
+++ b/src/bearagent/domain/tools.py
@@ -1,33 +1,201 @@
-"""Tool request and result types shared by ports and adapters."""
+"""Bounded Tool contracts shared by the runtime, ports, and adapters."""
 
+import json
 from collections.abc import Mapping
-from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import Self
 
+from pydantic import Field, JsonValue, field_serializer, field_validator, model_validator
 
-def _empty_arguments() -> Mapping[str, object]:
-    return {}
+from bearagent.domain._base import (
+    DomainModel,
+    freeze_json_mapping,
+    thaw_json_mapping,
+    validate_json_object,
+)
+from bearagent.domain.errors import ErrorInfo
+from bearagent.domain.ids import ToolCallId
+from bearagent.domain.messages import TOOL_NAME_PATTERN
+
+MAX_TOOL_DESCRIPTION_CHARS = 4_096
+MAX_TOOL_SCHEMA_BYTES = 1_000_000
+MAX_TOOL_ARGUMENT_BYTES = 1_000_000
+MAX_TOOL_TIMEOUT_MS = 600_000
+MAX_TOOL_INPUT_BYTES = 1_000_000
+MAX_TOOL_OUTPUT_BYTES = 4_000_000
 
 
 class ToolStatus(StrEnum):
-    """Terminal status returned by a P0 test tool."""
+    """Terminal outcome of one Tool call."""
 
     SUCCEEDED = "succeeded"
     FAILED = "failed"
 
 
-@dataclass(frozen=True, slots=True)
-class ToolRequest:
-    """A provider-neutral request to execute a named tool."""
+class ToolSideEffect(StrEnum):
+    """Trusted description of what a registered Tool can change."""
 
-    name: str
-    arguments: Mapping[str, object] = field(default_factory=_empty_arguments)
+    READ_ONLY = "read_only"
+    WORKSPACE_WRITE = "workspace_write"
+    EXTERNAL_WRITE = "external_write"
+    CODE_EXECUTION = "code_execution"
 
 
-@dataclass(frozen=True, slots=True)
-class ToolResult:
-    """A structured P0 tool result."""
+class ToolRetrySafety(StrEnum):
+    """Whether a later runtime may safely retry a Tool call."""
 
+    NOT_SAFE = "not_safe"
+    SAFE = "safe"
+
+
+class PolicyOutcome(StrEnum):
+    """P1 Policy outcomes."""
+
+    ALLOW = "allow"
+    DENY = "deny"
+
+
+class PolicyReason(StrEnum):
+    """Stable reasons for the P1 fixed Policy decision."""
+
+    ALLOWED = "allowed"
+    TOOL_NOT_ALLOWED = "tool_not_allowed"
+    SIDE_EFFECT_DENIED = "side_effect_denied"
+
+
+class PolicyDecision(DomainModel):
+    """A safe Policy result that contains no request argument copy."""
+
+    outcome: PolicyOutcome
+    reason: PolicyReason
+
+    @model_validator(mode="after")
+    def require_matching_outcome_and_reason(self) -> Self:
+        if self.outcome is PolicyOutcome.ALLOW and self.reason is not PolicyReason.ALLOWED:
+            raise ValueError("allow decision requires the allowed reason")
+        if self.outcome is PolicyOutcome.DENY and self.reason is PolicyReason.ALLOWED:
+            raise ValueError("deny decision requires a denial reason")
+        return self
+
+
+class ToolSpec(DomainModel):
+    """Trusted registration data and resource limits for one Tool."""
+
+    name: str = Field(pattern=TOOL_NAME_PATTERN)
+    description: str = Field(min_length=1, max_length=MAX_TOOL_DESCRIPTION_CHARS)
+    input_schema: Mapping[str, JsonValue]
+    output_schema: Mapping[str, JsonValue]
+    side_effect: ToolSideEffect
+    timeout_ms: int = Field(gt=0, le=MAX_TOOL_TIMEOUT_MS, strict=True)
+    max_input_bytes: int = Field(gt=0, le=MAX_TOOL_INPUT_BYTES, strict=True)
+    max_output_bytes: int = Field(gt=0, le=MAX_TOOL_OUTPUT_BYTES, strict=True)
+    retry_safety: ToolRetrySafety
+
+    @field_validator("description")
+    @classmethod
+    def reject_blank_description(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("description must not be blank")
+        return value
+
+    @field_validator("input_schema", "output_schema", mode="before")
+    @classmethod
+    def require_json_schema_object(cls, value: object) -> object:
+        return validate_json_object(value)
+
+    @field_validator("input_schema", "output_schema")
+    @classmethod
+    def freeze_object_schema(cls, value: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
+        if value.get("type") != "object":
+            raise ValueError("Tool schema root type must be object")
+        return freeze_json_mapping(value)
+
+    @field_serializer("input_schema", "output_schema")
+    def serialize_schema(self, value: Mapping[str, JsonValue]) -> dict[str, JsonValue]:
+        return thaw_json_mapping(value)
+
+    @model_validator(mode="after")
+    def require_bounded_schemas(self) -> Self:
+        for field_name, schema in (
+            ("input_schema", self.input_schema),
+            ("output_schema", self.output_schema),
+        ):
+            if _json_bytes(schema) > MAX_TOOL_SCHEMA_BYTES:
+                raise ValueError(f"{field_name} exceeds the Tool schema byte limit")
+        return self
+
+
+class ToolRequest(DomainModel):
+    """Untrusted model request for one named Tool."""
+
+    tool_call_id: ToolCallId
+    name: str = Field(pattern=TOOL_NAME_PATTERN)
+    arguments: Mapping[str, JsonValue] = Field(default_factory=dict)
+
+    @field_validator("arguments", mode="before")
+    @classmethod
+    def require_json_arguments(cls, value: object) -> object:
+        return validate_json_object(value)
+
+    @field_validator("arguments")
+    @classmethod
+    def freeze_arguments(cls, value: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
+        return freeze_json_mapping(value)
+
+    @field_serializer("arguments")
+    def serialize_arguments(self, value: Mapping[str, JsonValue]) -> dict[str, JsonValue]:
+        return thaw_json_mapping(value)
+
+    @model_validator(mode="after")
+    def require_bounded_arguments(self) -> Self:
+        if _json_bytes(self.arguments) > MAX_TOOL_ARGUMENT_BYTES:
+            raise ValueError("Tool arguments exceed the byte limit")
+        return self
+
+
+class PreparedToolRequest(ToolRequest):
+    """Tool request after pure, Tool-specific validation and normalization."""
+
+
+class ToolResult(DomainModel):
+    """Bounded structured result correlated with one Tool request."""
+
+    tool_call_id: ToolCallId
     status: ToolStatus
-    content: str = ""
-    error_code: str | None = None
+    data: Mapping[str, JsonValue] = Field(default_factory=dict)
+    error: ErrorInfo | None = None
+
+    @field_validator("data", mode="before")
+    @classmethod
+    def require_json_data(cls, value: object) -> object:
+        return validate_json_object(value)
+
+    @field_validator("data")
+    @classmethod
+    def freeze_data(cls, value: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
+        return freeze_json_mapping(value)
+
+    @field_serializer("data")
+    def serialize_data(self, value: Mapping[str, JsonValue]) -> dict[str, JsonValue]:
+        return thaw_json_mapping(value)
+
+    @model_validator(mode="after")
+    def require_one_terminal_shape(self) -> Self:
+        if self.status is ToolStatus.SUCCEEDED and self.error is not None:
+            raise ValueError("successful Tool result cannot contain an error")
+        if self.status is ToolStatus.FAILED:
+            if self.error is None:
+                raise ValueError("failed Tool result requires an error")
+            if self.data:
+                raise ValueError("failed Tool result cannot contain data")
+        return self
+
+
+def _json_bytes(value: Mapping[str, JsonValue]) -> int:
+    serialized = json.dumps(
+        thaw_json_mapping(value),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return len(serialized.encode("utf-8"))

--- a/src/bearagent/ports/__init__.py
+++ b/src/bearagent/ports/__init__.py
@@ -1,6 +1,7 @@
 """Framework-independent contracts implemented by BearAgent adapters."""
 
 from bearagent.ports.model import ModelProvider, ModelProviderError
+from bearagent.ports.policy import ToolPolicy
 from bearagent.ports.store import (
     EventStore,
     EventStoreConflictError,
@@ -21,4 +22,5 @@ __all__ = [
     "ModelProvider",
     "ModelProviderError",
     "Tool",
+    "ToolPolicy",
 ]

--- a/src/bearagent/ports/policy.py
+++ b/src/bearagent/ports/policy.py
@@ -1,0 +1,11 @@
+"""Policy port for prepared Tool requests."""
+
+from typing import Protocol
+
+from bearagent.domain.tools import PolicyDecision, PreparedToolRequest, ToolSpec
+
+
+class ToolPolicy(Protocol):
+    """Decide whether one normalized Tool request may execute."""
+
+    def evaluate(self, spec: ToolSpec, request: PreparedToolRequest) -> PolicyDecision: ...

--- a/src/bearagent/ports/tools.py
+++ b/src/bearagent/ports/tools.py
@@ -1,13 +1,19 @@
-"""Tool execution port."""
+"""Tool preparation and execution port."""
 
 from typing import Protocol
 
-from bearagent.domain.tools import ToolRequest, ToolResult
+from bearagent.domain.tools import PreparedToolRequest, ToolRequest, ToolResult, ToolSpec
 
 
 class Tool(Protocol):
-    """Execute one typed tool request."""
+    """Validate and execute one registered Tool without exposing adapter types."""
 
-    name: str
+    spec: ToolSpec
 
-    async def execute(self, request: ToolRequest) -> ToolResult: ...
+    def prepare(self, request: ToolRequest) -> PreparedToolRequest:
+        """Validate and normalize arguments without external side effects."""
+        ...
+
+    async def execute(self, request: PreparedToolRequest) -> ToolResult:
+        """Perform the external operation once."""
+        ...

--- a/src/bearagent/runtime/__init__.py
+++ b/src/bearagent/runtime/__init__.py
@@ -1,6 +1,17 @@
 """Framework-independent BearAgent runtime state transitions."""
 
 from bearagent.runtime.budgets import check_activity_budget
+from bearagent.runtime.policy import FixedToolPolicy
 from bearagent.runtime.reducer import RunReducerError, reduce_event, reduce_events
+from bearagent.runtime.tool_executor import ToolExecutor
+from bearagent.runtime.tool_registry import ToolRegistry
 
-__all__ = ["RunReducerError", "check_activity_budget", "reduce_event", "reduce_events"]
+__all__ = [
+    "FixedToolPolicy",
+    "RunReducerError",
+    "ToolExecutor",
+    "ToolRegistry",
+    "check_activity_budget",
+    "reduce_event",
+    "reduce_events",
+]

--- a/src/bearagent/runtime/policy.py
+++ b/src/bearagent/runtime/policy.py
@@ -1,0 +1,62 @@
+"""Default-deny fixed Tool policy for P1."""
+
+import re
+from collections.abc import Iterable
+
+from bearagent.domain.messages import TOOL_NAME_PATTERN
+from bearagent.domain.tools import (
+    PolicyDecision,
+    PolicyOutcome,
+    PolicyReason,
+    PreparedToolRequest,
+    ToolSideEffect,
+    ToolSpec,
+)
+
+_DENIED_SIDE_EFFECTS = frozenset(
+    {
+        ToolSideEffect.EXTERNAL_WRITE,
+        ToolSideEffect.CODE_EXECUTION,
+    }
+)
+
+
+class FixedToolPolicy:
+    """Allow configured P1 Tools while hard-denying dangerous side effects."""
+
+    def __init__(self, allowed_tool_names: Iterable[str] = ()) -> None:
+        if isinstance(allowed_tool_names, str):
+            raise ValueError("allowed Tool names must be a collection, not one string")
+        names = _materialize_untrusted_names(allowed_tool_names)
+        validated_names: list[str] = []
+        for name in names:
+            if not isinstance(name, str) or re.fullmatch(TOOL_NAME_PATTERN, name) is None:
+                raise ValueError("allowed Tool name is invalid")
+            validated_names.append(name)
+        self._allowed_tool_names = frozenset(validated_names)
+
+    @property
+    def allowed_tool_names(self) -> frozenset[str]:
+        """Return the immutable trusted allowlist snapshot."""
+        return self._allowed_tool_names
+
+    def evaluate(self, spec: ToolSpec, request: PreparedToolRequest) -> PolicyDecision:
+        """Evaluate trusted Tool metadata and normalized arguments."""
+        if spec.name != request.name or spec.name not in self._allowed_tool_names:
+            return PolicyDecision(
+                outcome=PolicyOutcome.DENY,
+                reason=PolicyReason.TOOL_NOT_ALLOWED,
+            )
+        if spec.side_effect in _DENIED_SIDE_EFFECTS:
+            return PolicyDecision(
+                outcome=PolicyOutcome.DENY,
+                reason=PolicyReason.SIDE_EFFECT_DENIED,
+            )
+        return PolicyDecision(
+            outcome=PolicyOutcome.ALLOW,
+            reason=PolicyReason.ALLOWED,
+        )
+
+
+def _materialize_untrusted_names(names: Iterable[object]) -> tuple[object, ...]:
+    return tuple(names)

--- a/src/bearagent/runtime/tool_executor.py
+++ b/src/bearagent/runtime/tool_executor.py
@@ -1,0 +1,166 @@
+"""Single bounded execution path for every P1 Tool request."""
+
+import asyncio
+import json
+from collections.abc import Mapping
+
+from pydantic import JsonValue
+
+from bearagent.domain._base import thaw_json_mapping
+from bearagent.domain.errors import ErrorCategory, ErrorCode, ErrorInfo
+from bearagent.domain.tools import (
+    PolicyDecision,
+    PolicyOutcome,
+    PreparedToolRequest,
+    ToolRequest,
+    ToolResult,
+    ToolStatus,
+)
+from bearagent.ports.policy import ToolPolicy
+from bearagent.runtime.tool_registry import ToolRegistry
+
+
+class ToolExecutor:
+    """Resolve, prepare, authorize, and execute one Tool call at most once."""
+
+    def __init__(self, registry: ToolRegistry, policy: ToolPolicy) -> None:
+        self._registry = registry
+        self._policy = policy
+
+    async def execute(self, request: ToolRequest) -> ToolResult:
+        """Run one request through the complete P1 Tool boundary."""
+        tool = self._registry.get(request.name)
+        spec = self._registry.get_spec(request.name)
+        if tool is None or spec is None:
+            return _failure(
+                request,
+                ErrorCode.TOOL_NOT_FOUND,
+                "Tool is not registered.",
+            )
+        if _json_object_bytes(request.arguments) > spec.max_input_bytes:
+            return _failure(
+                request,
+                ErrorCode.TOOL_INVALID_INPUT,
+                "Tool request arguments exceed the input limit.",
+                details={"limit_bytes": spec.max_input_bytes},
+            )
+
+        try:
+            prepared_value = _runtime_value(tool.prepare(request))
+        except Exception:
+            return _failure(
+                request,
+                ErrorCode.TOOL_INVALID_INPUT,
+                "Tool request arguments are invalid.",
+            )
+        if not isinstance(prepared_value, PreparedToolRequest):
+            return _failure(
+                request,
+                ErrorCode.TOOL_INVALID_INPUT,
+                "Tool request preparation returned invalid data.",
+            )
+        prepared = prepared_value
+        if prepared.tool_call_id != request.tool_call_id or prepared.name != request.name:
+            return _failure(
+                request,
+                ErrorCode.TOOL_INVALID_INPUT,
+                "Tool request preparation returned invalid identity.",
+            )
+
+        try:
+            decision_value = _runtime_value(self._policy.evaluate(spec, prepared))
+        except Exception:
+            return _failure(
+                request,
+                ErrorCode.TOOL_ERROR,
+                "Tool policy evaluation failed.",
+            )
+        if not isinstance(decision_value, PolicyDecision):
+            return _failure(
+                request,
+                ErrorCode.TOOL_ERROR,
+                "Tool policy returned an invalid decision.",
+            )
+        decision = decision_value
+        if decision.outcome is PolicyOutcome.DENY:
+            return _failure(
+                request,
+                ErrorCode.TOOL_PERMISSION_DENIED,
+                "Tool request is not allowed.",
+                details={"policy_reason": decision.reason.value},
+            )
+
+        try:
+            async with asyncio.timeout(spec.timeout_ms / 1_000):
+                result_value = _runtime_value(await tool.execute(prepared))
+        except TimeoutError:
+            return _failure(
+                request,
+                ErrorCode.TOOL_TIMEOUT,
+                "Tool execution timed out.",
+            )
+        except Exception:
+            return _failure(
+                request,
+                ErrorCode.TOOL_ERROR,
+                "Tool execution failed.",
+            )
+
+        if not isinstance(result_value, ToolResult):
+            return _failure(
+                request,
+                ErrorCode.TOOL_ERROR,
+                "Tool returned invalid result data.",
+            )
+        result = result_value
+        if result.tool_call_id != request.tool_call_id:
+            return _failure(
+                request,
+                ErrorCode.TOOL_ERROR,
+                "Tool returned an invalid result.",
+            )
+        if result.status is ToolStatus.SUCCEEDED:
+            output_bytes = _json_object_bytes(result.data)
+            if output_bytes > spec.max_output_bytes:
+                return _failure(
+                    request,
+                    ErrorCode.TOOL_OUTPUT_TOO_LARGE,
+                    "Tool result exceeds the output limit.",
+                    details={"limit_bytes": spec.max_output_bytes},
+                )
+        return result
+
+
+def _json_object_bytes(data: Mapping[str, JsonValue]) -> int:
+    serialized = json.dumps(
+        thaw_json_mapping(data),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return len(serialized.encode("utf-8"))
+
+
+def _runtime_value(value: object) -> object:
+    """Erase static adapter promises before checking the runtime boundary."""
+    return value
+
+
+def _failure(
+    request: ToolRequest,
+    code: ErrorCode,
+    message: str,
+    *,
+    details: Mapping[str, str | int] | None = None,
+) -> ToolResult:
+    return ToolResult(
+        tool_call_id=request.tool_call_id,
+        status=ToolStatus.FAILED,
+        error=ErrorInfo(
+            category=ErrorCategory.TOOL,
+            code=code,
+            message=message,
+            retryable=False,
+            details={} if details is None else details,
+        ),
+    )

--- a/src/bearagent/runtime/tool_registry.py
+++ b/src/bearagent/runtime/tool_registry.py
@@ -1,0 +1,37 @@
+"""Immutable registry of trusted Tool implementations."""
+
+from collections.abc import Iterable, Mapping
+from types import MappingProxyType
+
+from bearagent.domain.tools import ToolSpec
+from bearagent.ports.tools import Tool
+
+
+class ToolRegistry:
+    """Snapshot registered Tools and resolve them by exact name."""
+
+    def __init__(self, tools: Iterable[Tool]) -> None:
+        by_name: dict[str, Tool] = {}
+        specs_by_name: dict[str, ToolSpec] = {}
+        for tool in tools:
+            name = tool.spec.name
+            if name in by_name:
+                raise ValueError(f"duplicate Tool name: {name}")
+            by_name[name] = tool
+            specs_by_name[name] = tool.spec
+        self._tools: Mapping[str, Tool] = MappingProxyType(by_name)
+        self._specs_by_name: Mapping[str, ToolSpec] = MappingProxyType(specs_by_name)
+        self._specs = tuple(specs_by_name[name] for name in sorted(specs_by_name))
+
+    @property
+    def specs(self) -> tuple[ToolSpec, ...]:
+        """Return trusted Tool definitions in stable name order."""
+        return self._specs
+
+    def get(self, name: str) -> Tool | None:
+        """Return the exact registered Tool, without aliases or fallback."""
+        return self._tools.get(name)
+
+    def get_spec(self, name: str) -> ToolSpec | None:
+        """Return the immutable registration-time Tool definition."""
+        return self._specs_by_name.get(name)

--- a/tests/contract/snapshots/domain_schemas.json
+++ b/tests/contract/snapshots/domain_schemas.json
@@ -62,6 +62,11 @@
           "provider_invalid_request",
           "provider_refused",
           "provider_protocol_error",
+          "tool_not_found",
+          "tool_invalid_input",
+          "tool_permission_denied",
+          "tool_timeout",
+          "tool_output_too_large",
           "tool_error",
           "persistence_error",
           "internal_error"
@@ -421,6 +426,11 @@
           "provider_invalid_request",
           "provider_refused",
           "provider_protocol_error",
+          "tool_not_found",
+          "tool_invalid_input",
+          "tool_permission_denied",
+          "tool_timeout",
+          "tool_output_too_large",
           "tool_error",
           "persistence_error",
           "internal_error"
@@ -825,6 +835,11 @@
           "provider_invalid_request",
           "provider_refused",
           "provider_protocol_error",
+          "tool_not_found",
+          "tool_invalid_input",
+          "tool_permission_denied",
+          "tool_timeout",
+          "tool_output_too_large",
           "tool_error",
           "persistence_error",
           "internal_error"
@@ -1464,6 +1479,81 @@
     "title": "ModelUsage",
     "type": "object"
   },
+  "PolicyDecision": {
+    "$defs": {
+      "PolicyOutcome": {
+        "description": "P1 Policy outcomes.",
+        "enum": [
+          "allow",
+          "deny"
+        ],
+        "title": "PolicyOutcome",
+        "type": "string"
+      },
+      "PolicyReason": {
+        "description": "Stable reasons for the P1 fixed Policy decision.",
+        "enum": [
+          "allowed",
+          "tool_not_allowed",
+          "side_effect_denied"
+        ],
+        "title": "PolicyReason",
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "description": "A safe Policy result that contains no request argument copy.",
+    "properties": {
+      "outcome": {
+        "$ref": "#/$defs/PolicyOutcome"
+      },
+      "reason": {
+        "$ref": "#/$defs/PolicyReason"
+      }
+    },
+    "required": [
+      "outcome",
+      "reason"
+    ],
+    "title": "PolicyDecision",
+    "type": "object"
+  },
+  "PreparedToolRequest": {
+    "$defs": {
+      "JsonValue": {},
+      "ToolCallId": {
+        "description": "Correlate one tool request with its result.",
+        "format": "uuid4",
+        "title": "ToolCallId",
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Tool request after pure, Tool-specific validation and normalization.",
+    "properties": {
+      "tool_call_id": {
+        "$ref": "#/$defs/ToolCallId"
+      },
+      "name": {
+        "pattern": "^[A-Za-z][A-Za-z0-9_.-]{0,127}$",
+        "title": "Name",
+        "type": "string"
+      },
+      "arguments": {
+        "additionalProperties": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "title": "Arguments",
+        "type": "object"
+      }
+    },
+    "required": [
+      "tool_call_id",
+      "name"
+    ],
+    "title": "PreparedToolRequest",
+    "type": "object"
+  },
   "RunCreatedPayload": {
     "$defs": {
       "BudgetLimits": {
@@ -1566,6 +1656,11 @@
           "provider_invalid_request",
           "provider_refused",
           "provider_protocol_error",
+          "tool_not_found",
+          "tool_invalid_input",
+          "tool_permission_denied",
+          "tool_timeout",
+          "tool_output_too_large",
           "tool_error",
           "persistence_error",
           "internal_error"
@@ -1902,6 +1997,11 @@
           "provider_invalid_request",
           "provider_refused",
           "provider_protocol_error",
+          "tool_not_found",
+          "tool_invalid_input",
+          "tool_permission_denied",
+          "tool_timeout",
+          "tool_output_too_large",
           "tool_error",
           "persistence_error",
           "internal_error"
@@ -2169,6 +2269,11 @@
           "provider_invalid_request",
           "provider_refused",
           "provider_protocol_error",
+          "tool_not_found",
+          "tool_invalid_input",
+          "tool_permission_denied",
+          "tool_timeout",
+          "tool_output_too_large",
           "tool_error",
           "persistence_error",
           "internal_error"
@@ -2335,6 +2440,285 @@
       "tool_call_id"
     ],
     "title": "ToolCallStartedPayload",
+    "type": "object"
+  },
+  "ToolRequest": {
+    "$defs": {
+      "JsonValue": {},
+      "ToolCallId": {
+        "description": "Correlate one tool request with its result.",
+        "format": "uuid4",
+        "title": "ToolCallId",
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Untrusted model request for one named Tool.",
+    "properties": {
+      "tool_call_id": {
+        "$ref": "#/$defs/ToolCallId"
+      },
+      "name": {
+        "pattern": "^[A-Za-z][A-Za-z0-9_.-]{0,127}$",
+        "title": "Name",
+        "type": "string"
+      },
+      "arguments": {
+        "additionalProperties": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "title": "Arguments",
+        "type": "object"
+      }
+    },
+    "required": [
+      "tool_call_id",
+      "name"
+    ],
+    "title": "ToolRequest",
+    "type": "object"
+  },
+  "ToolResult": {
+    "$defs": {
+      "ErrorCategory": {
+        "description": "Stable high-level class used for handling and aggregation.",
+        "enum": [
+          "validation",
+          "budget",
+          "provider",
+          "tool",
+          "persistence",
+          "internal"
+        ],
+        "title": "ErrorCategory",
+        "type": "string"
+      },
+      "ErrorCode": {
+        "description": "Initial stable error codes; later Features may add specific codes.",
+        "enum": [
+          "invalid_input",
+          "invalid_event",
+          "invalid_state_transition",
+          "budget_exhausted",
+          "provider_error",
+          "provider_timeout",
+          "provider_rate_limited",
+          "provider_unavailable",
+          "provider_authentication",
+          "provider_permission_denied",
+          "provider_invalid_request",
+          "provider_refused",
+          "provider_protocol_error",
+          "tool_not_found",
+          "tool_invalid_input",
+          "tool_permission_denied",
+          "tool_timeout",
+          "tool_output_too_large",
+          "tool_error",
+          "persistence_error",
+          "internal_error"
+        ],
+        "title": "ErrorCode",
+        "type": "string"
+      },
+      "ErrorInfo": {
+        "additionalProperties": false,
+        "description": "Serializable error data that is safe to expose and persist.",
+        "properties": {
+          "category": {
+            "$ref": "#/$defs/ErrorCategory"
+          },
+          "code": {
+            "$ref": "#/$defs/ErrorCode"
+          },
+          "message": {
+            "maxLength": 1000,
+            "minLength": 1,
+            "title": "Message",
+            "type": "string"
+          },
+          "retryable": {
+            "default": false,
+            "title": "Retryable",
+            "type": "boolean"
+          },
+          "details": {
+            "additionalProperties": {
+              "$ref": "#/$defs/SafeDetailValue"
+            },
+            "maxProperties": 32,
+            "title": "Details",
+            "type": "object"
+          }
+        },
+        "required": [
+          "category",
+          "code",
+          "message"
+        ],
+        "title": "ErrorInfo",
+        "type": "object"
+      },
+      "JsonValue": {},
+      "SafeDetailValue": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "ToolCallId": {
+        "description": "Correlate one tool request with its result.",
+        "format": "uuid4",
+        "title": "ToolCallId",
+        "type": "string"
+      },
+      "ToolStatus": {
+        "description": "Terminal outcome of one Tool call.",
+        "enum": [
+          "succeeded",
+          "failed"
+        ],
+        "title": "ToolStatus",
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Bounded structured result correlated with one Tool request.",
+    "properties": {
+      "tool_call_id": {
+        "$ref": "#/$defs/ToolCallId"
+      },
+      "status": {
+        "$ref": "#/$defs/ToolStatus"
+      },
+      "data": {
+        "additionalProperties": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "title": "Data",
+        "type": "object"
+      },
+      "error": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/ErrorInfo"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      }
+    },
+    "required": [
+      "tool_call_id",
+      "status"
+    ],
+    "title": "ToolResult",
+    "type": "object"
+  },
+  "ToolSpec": {
+    "$defs": {
+      "JsonValue": {},
+      "ToolRetrySafety": {
+        "description": "Whether a later runtime may safely retry a Tool call.",
+        "enum": [
+          "not_safe",
+          "safe"
+        ],
+        "title": "ToolRetrySafety",
+        "type": "string"
+      },
+      "ToolSideEffect": {
+        "description": "Trusted description of what a registered Tool can change.",
+        "enum": [
+          "read_only",
+          "workspace_write",
+          "external_write",
+          "code_execution"
+        ],
+        "title": "ToolSideEffect",
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Trusted registration data and resource limits for one Tool.",
+    "properties": {
+      "name": {
+        "pattern": "^[A-Za-z][A-Za-z0-9_.-]{0,127}$",
+        "title": "Name",
+        "type": "string"
+      },
+      "description": {
+        "maxLength": 4096,
+        "minLength": 1,
+        "title": "Description",
+        "type": "string"
+      },
+      "input_schema": {
+        "additionalProperties": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "title": "Input Schema",
+        "type": "object"
+      },
+      "output_schema": {
+        "additionalProperties": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "title": "Output Schema",
+        "type": "object"
+      },
+      "side_effect": {
+        "$ref": "#/$defs/ToolSideEffect"
+      },
+      "timeout_ms": {
+        "exclusiveMinimum": 0,
+        "maximum": 600000,
+        "title": "Timeout Ms",
+        "type": "integer"
+      },
+      "max_input_bytes": {
+        "exclusiveMinimum": 0,
+        "maximum": 1000000,
+        "title": "Max Input Bytes",
+        "type": "integer"
+      },
+      "max_output_bytes": {
+        "exclusiveMinimum": 0,
+        "maximum": 4000000,
+        "title": "Max Output Bytes",
+        "type": "integer"
+      },
+      "retry_safety": {
+        "$ref": "#/$defs/ToolRetrySafety"
+      }
+    },
+    "required": [
+      "name",
+      "description",
+      "input_schema",
+      "output_schema",
+      "side_effect",
+      "timeout_ms",
+      "max_input_bytes",
+      "max_output_bytes",
+      "retry_safety"
+    ],
+    "title": "ToolSpec",
     "type": "object"
   }
 }

--- a/tests/contract/test_tool_contract.py
+++ b/tests/contract/test_tool_contract.py
@@ -1,0 +1,48 @@
+import asyncio
+
+from tests.tool_fixtures import build_tool_request, build_tool_spec
+
+from bearagent.adapters.testing import FakeTool
+from bearagent.domain.errors import ErrorCategory, ErrorCode, ErrorInfo
+from bearagent.domain.tools import ToolStatus
+
+
+def test_fake_tool_prepares_executes_and_records_one_request() -> None:
+    async def exercise() -> None:
+        request = build_tool_request(arguments={"path": "docs/./index.md"})
+        tool = FakeTool(
+            build_tool_spec(),
+            data={"content": "BearAgent"},
+            prepared_arguments={"path": "docs/index.md"},
+        )
+
+        prepared = tool.prepare(request)
+        result = await tool.execute(prepared)
+
+        assert tool.prepare_requests == [request]
+        assert tool.requests == [prepared]
+        assert prepared.arguments == {"path": "docs/index.md"}
+        assert result.tool_call_id == request.tool_call_id
+        assert result.status is ToolStatus.SUCCEEDED
+        assert result.data == {"content": "BearAgent"}
+
+    asyncio.run(exercise())
+
+
+def test_fake_tool_returns_configured_safe_failure() -> None:
+    async def exercise() -> None:
+        failure = ErrorInfo(
+            category=ErrorCategory.TOOL,
+            code=ErrorCode.TOOL_ERROR,
+            message="Test Tool failed.",
+        )
+        request = build_tool_request()
+        tool = FakeTool(build_tool_spec(), failure=failure)
+
+        result = await tool.execute(tool.prepare(request))
+
+        assert result.status is ToolStatus.FAILED
+        assert result.error == failure
+        assert result.data == {}
+
+    asyncio.run(exercise())

--- a/tests/integration/test_tool_executor.py
+++ b/tests/integration/test_tool_executor.py
@@ -1,0 +1,96 @@
+import asyncio
+
+from tests.tool_fixtures import build_tool_request, build_tool_spec
+
+from bearagent.adapters.testing import FakeTool
+from bearagent.domain.errors import ErrorCategory, ErrorCode, ErrorInfo
+from bearagent.domain.tools import (
+    PolicyDecision,
+    PolicyOutcome,
+    PolicyReason,
+    PreparedToolRequest,
+    ToolResult,
+    ToolSpec,
+    ToolStatus,
+)
+from bearagent.runtime.policy import FixedToolPolicy
+from bearagent.runtime.tool_executor import ToolExecutor
+from bearagent.runtime.tool_registry import ToolRegistry
+
+
+class RecordingAllowPolicy:
+    def __init__(self) -> None:
+        self.requests: list[PreparedToolRequest] = []
+
+    def evaluate(self, spec: ToolSpec, request: PreparedToolRequest) -> PolicyDecision:
+        self.requests.append(request)
+        return PolicyDecision(outcome=PolicyOutcome.ALLOW, reason=PolicyReason.ALLOWED)
+
+
+def test_executor_prepares_before_policy_and_executes_once() -> None:
+    async def exercise() -> tuple[ToolResult, FakeTool, RecordingAllowPolicy]:
+        request = build_tool_request(arguments={"path": "docs/./index.md"})
+        tool = FakeTool(
+            build_tool_spec(),
+            data={"content": "BearAgent"},
+            prepared_arguments={"path": "docs/index.md"},
+        )
+        policy = RecordingAllowPolicy()
+        executor = ToolExecutor(ToolRegistry([tool]), policy)
+
+        result = await executor.execute(request)
+        return result, tool, policy
+
+    result, tool, policy = asyncio.run(exercise())
+
+    assert result.status is ToolStatus.SUCCEEDED
+    assert len(tool.prepare_requests) == 1
+    assert len(tool.requests) == 1
+    assert policy.requests == tool.requests
+    assert policy.requests[0].arguments == {"path": "docs/index.md"}
+
+
+def test_executor_rejects_unknown_tool_before_any_adapter_call() -> None:
+    result = asyncio.run(
+        ToolExecutor(ToolRegistry([]), FixedToolPolicy()).execute(build_tool_request())
+    )
+
+    assert result.status is ToolStatus.FAILED
+    assert result.error is not None
+    assert result.error.code is ErrorCode.TOOL_NOT_FOUND
+
+
+def test_executor_rejects_denied_tool_before_execute() -> None:
+    async def exercise() -> tuple[ToolResult, FakeTool]:
+        tool = FakeTool(build_tool_spec(), data={"content": "not reached"})
+        executor = ToolExecutor(ToolRegistry([tool]), FixedToolPolicy())
+        return await executor.execute(build_tool_request()), tool
+
+    result, tool = asyncio.run(exercise())
+
+    assert len(tool.prepare_requests) == 1
+    assert tool.requests == []
+    assert result.error is not None
+    assert result.error.code is ErrorCode.TOOL_PERMISSION_DENIED
+    assert result.error.details == {"policy_reason": "tool_not_allowed"}
+
+
+def test_executor_preserves_valid_tool_failure() -> None:
+    async def exercise() -> ToolResult:
+        failure = ErrorInfo(
+            category=ErrorCategory.TOOL,
+            code=ErrorCode.TOOL_ERROR,
+            message="Read failed safely.",
+        )
+        tool = FakeTool(build_tool_spec(), failure=failure)
+        executor = ToolExecutor(
+            ToolRegistry([tool]),
+            FixedToolPolicy(["workspace.read"]),
+        )
+        return await executor.execute(build_tool_request())
+
+    result = asyncio.run(exercise())
+
+    assert result.status is ToolStatus.FAILED
+    assert result.error is not None
+    assert result.error.message == "Read failed safely."

--- a/tests/security/test_tool_executor.py
+++ b/tests/security/test_tool_executor.py
@@ -1,0 +1,125 @@
+import asyncio
+
+import pytest
+from tests.tool_fixtures import build_tool_request, build_tool_spec
+
+from bearagent.adapters.testing import FakeTool
+from bearagent.domain.errors import ErrorCode
+from bearagent.domain.tools import ToolResult, ToolSideEffect, ToolStatus
+from bearagent.runtime.policy import FixedToolPolicy
+from bearagent.runtime.tool_executor import ToolExecutor
+from bearagent.runtime.tool_registry import ToolRegistry
+
+
+def executor_for(tool: FakeTool) -> ToolExecutor:
+    return ToolExecutor(
+        ToolRegistry([tool]),
+        FixedToolPolicy([tool.spec.name]),
+    )
+
+
+def test_prepare_failure_is_safe_and_prevents_execution() -> None:
+    secret = "secret-api-key-value"
+    tool = FakeTool(build_tool_spec(), prepare_error=ValueError(secret))
+
+    result = asyncio.run(executor_for(tool).execute(build_tool_request()))
+
+    assert tool.requests == []
+    assert result.error is not None
+    assert result.error.code is ErrorCode.TOOL_INVALID_INPUT
+    assert secret not in result.model_dump_json()
+
+
+def test_oversized_input_is_rejected_before_prepare() -> None:
+    tool = FakeTool(
+        build_tool_spec(max_input_bytes=20),
+        data={"content": "not reached"},
+    )
+
+    result = asyncio.run(
+        executor_for(tool).execute(build_tool_request(arguments={"path": "x" * 100}))
+    )
+
+    assert tool.prepare_requests == []
+    assert tool.requests == []
+    assert result.error is not None
+    assert result.error.code is ErrorCode.TOOL_INVALID_INPUT
+
+
+def test_replacing_tool_spec_after_registration_cannot_weaken_policy() -> None:
+    tool = FakeTool(
+        build_tool_spec(name="danger.run", side_effect=ToolSideEffect.CODE_EXECUTION),
+        data={"content": "not reached"},
+    )
+    registry = ToolRegistry([tool])
+    tool.spec = build_tool_spec(name="danger.run", side_effect=ToolSideEffect.READ_ONLY)
+    executor = ToolExecutor(registry, FixedToolPolicy(["danger.run"]))
+
+    result = asyncio.run(executor.execute(build_tool_request(name="danger.run")))
+
+    assert tool.requests == []
+    assert result.error is not None
+    assert result.error.code is ErrorCode.TOOL_PERMISSION_DENIED
+
+
+def test_timeout_calls_tool_once_and_does_not_retry() -> None:
+    tool = FakeTool(
+        build_tool_spec(timeout_ms=10),
+        data={"content": "late"},
+        delay_seconds=0.1,
+    )
+
+    result = asyncio.run(executor_for(tool).execute(build_tool_request()))
+
+    assert len(tool.requests) == 1
+    assert result.error is not None
+    assert result.error.code is ErrorCode.TOOL_TIMEOUT
+    assert result.error.retryable is False
+
+
+def test_execute_exception_is_safe_and_not_retried() -> None:
+    secret = "authorization-bearer-secret"
+    tool = FakeTool(build_tool_spec(), execute_error=RuntimeError(secret))
+
+    result = asyncio.run(executor_for(tool).execute(build_tool_request()))
+
+    assert len(tool.requests) == 1
+    assert result.error is not None
+    assert result.error.code is ErrorCode.TOOL_ERROR
+    assert secret not in result.model_dump_json()
+
+
+def test_oversized_structured_result_fails_without_returning_partial_data() -> None:
+    tool = FakeTool(
+        build_tool_spec(max_output_bytes=20),
+        data={"content": "x" * 100},
+    )
+
+    result = asyncio.run(executor_for(tool).execute(build_tool_request()))
+
+    assert len(tool.requests) == 1
+    assert result.status is ToolStatus.FAILED
+    assert result.data == {}
+    assert result.error is not None
+    assert result.error.code is ErrorCode.TOOL_OUTPUT_TOO_LARGE
+
+
+def test_caller_cancellation_propagates_without_a_fake_result() -> None:
+    async def exercise() -> tuple[FakeTool, ToolResult | None]:
+        tool = FakeTool(
+            build_tool_spec(timeout_ms=5_000),
+            data={"content": "late"},
+            delay_seconds=10,
+        )
+        task = asyncio.create_task(executor_for(tool).execute(build_tool_request()))
+        await asyncio.sleep(0)
+        task.cancel()
+        result: ToolResult | None = None
+        with pytest.raises(asyncio.CancelledError):
+            result = await task
+        return tool, result
+
+    tool, result = asyncio.run(exercise())
+
+    assert len(tool.requests) == 1
+    assert result is None

--- a/tests/security/test_tool_policy.py
+++ b/tests/security/test_tool_policy.py
@@ -1,0 +1,83 @@
+import pytest
+from tests.tool_fixtures import build_tool_request, build_tool_spec
+
+from bearagent.domain.tools import (
+    PolicyOutcome,
+    PolicyReason,
+    PreparedToolRequest,
+    ToolSideEffect,
+)
+from bearagent.runtime.policy import FixedToolPolicy
+
+
+def prepared_request(name: str = "workspace.read") -> PreparedToolRequest:
+    request = build_tool_request(name=name)
+    return PreparedToolRequest.model_validate(request.model_dump(mode="json"))
+
+
+def test_policy_denies_by_default() -> None:
+    decision = FixedToolPolicy().evaluate(build_tool_spec(), prepared_request())
+
+    assert decision.outcome is PolicyOutcome.DENY
+    assert decision.reason is PolicyReason.TOOL_NOT_ALLOWED
+
+
+def test_policy_allows_configured_read_and_workspace_write() -> None:
+    policy = FixedToolPolicy(["workspace.read", "workspace.write"])
+
+    read = policy.evaluate(build_tool_spec(), prepared_request())
+    write = policy.evaluate(
+        build_tool_spec(name="workspace.write", side_effect=ToolSideEffect.WORKSPACE_WRITE),
+        prepared_request("workspace.write"),
+    )
+
+    assert read.outcome is PolicyOutcome.ALLOW
+    assert write.outcome is PolicyOutcome.ALLOW
+
+
+@pytest.mark.parametrize(
+    "side_effect",
+    [ToolSideEffect.EXTERNAL_WRITE, ToolSideEffect.CODE_EXECUTION],
+)
+def test_policy_hard_denies_dangerous_side_effects(side_effect: ToolSideEffect) -> None:
+    policy = FixedToolPolicy(["danger.run"])
+
+    decision = policy.evaluate(
+        build_tool_spec(name="danger.run", side_effect=side_effect),
+        prepared_request("danger.run"),
+    )
+
+    assert decision.outcome is PolicyOutcome.DENY
+    assert decision.reason is PolicyReason.SIDE_EFFECT_DENIED
+
+
+def test_model_arguments_and_external_mutation_cannot_expand_allowlist() -> None:
+    allowed = ["workspace.read"]
+    policy = FixedToolPolicy(allowed)
+    allowed.append("danger.run")
+    request = build_tool_request(
+        name="danger.run",
+        arguments={"allow": True, "grant": "danger.run"},
+    )
+
+    decision = policy.evaluate(
+        build_tool_spec(name="danger.run"),
+        PreparedToolRequest.model_validate(request.model_dump(mode="json")),
+    )
+
+    assert decision.outcome is PolicyOutcome.DENY
+    assert policy.allowed_tool_names == frozenset({"workspace.read"})
+
+
+def test_policy_denies_mismatched_prepared_request() -> None:
+    decision = FixedToolPolicy(["workspace.read"]).evaluate(
+        build_tool_spec(),
+        prepared_request("workspace.search"),
+    )
+
+    assert decision.outcome is PolicyOutcome.DENY
+
+
+def test_policy_rejects_one_string_as_an_allowlist_collection() -> None:
+    with pytest.raises(ValueError, match="must be a collection"):
+        FixedToolPolicy("workspace.read")

--- a/tests/tool_fixtures.py
+++ b/tests/tool_fixtures.py
@@ -1,0 +1,54 @@
+from collections.abc import Mapping
+
+from pydantic import JsonValue
+
+from bearagent.domain.ids import ToolCallId
+from bearagent.domain.tools import (
+    ToolRequest,
+    ToolRetrySafety,
+    ToolSideEffect,
+    ToolSpec,
+)
+
+
+def build_tool_spec(
+    *,
+    name: str = "workspace.read",
+    side_effect: ToolSideEffect = ToolSideEffect.READ_ONLY,
+    timeout_ms: int = 1_000,
+    max_input_bytes: int = 1_024,
+    max_output_bytes: int = 1_024,
+) -> ToolSpec:
+    return ToolSpec(
+        name=name,
+        description="Read one test resource.",
+        input_schema={
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+            "additionalProperties": False,
+        },
+        output_schema={
+            "type": "object",
+            "properties": {"content": {"type": "string"}},
+            "required": ["content"],
+            "additionalProperties": False,
+        },
+        side_effect=side_effect,
+        timeout_ms=timeout_ms,
+        max_input_bytes=max_input_bytes,
+        max_output_bytes=max_output_bytes,
+        retry_safety=ToolRetrySafety.SAFE,
+    )
+
+
+def build_tool_request(
+    *,
+    name: str = "workspace.read",
+    arguments: Mapping[str, JsonValue] | None = None,
+) -> ToolRequest:
+    return ToolRequest(
+        tool_call_id=ToolCallId.new(),
+        name=name,
+        arguments={"path": "docs/index.md"} if arguments is None else arguments,
+    )

--- a/tests/unit/test_testing_adapters.py
+++ b/tests/unit/test_testing_adapters.py
@@ -2,6 +2,7 @@ import asyncio
 from datetime import UTC, datetime
 
 import pytest
+from tests.tool_fixtures import build_tool_request, build_tool_spec
 
 from bearagent.adapters.testing import (
     EventSequenceError,
@@ -20,7 +21,7 @@ from bearagent.domain.model import (
     ModelTextDelta,
 )
 from bearagent.domain.runs import BudgetLimits
-from bearagent.domain.tools import ToolRequest, ToolResult, ToolStatus
+from bearagent.domain.tools import ToolStatus
 from bearagent.runtime.reducer import RunReducerError
 
 
@@ -54,15 +55,17 @@ def test_fake_model_returns_configured_events_and_records_request() -> None:
 
 
 def test_fake_tool_returns_configured_result_and_records_request() -> None:
-    async def exercise() -> ToolResult:
-        expected = ToolResult(ToolStatus.SUCCEEDED, content="done")
-        tool = FakeTool("example", expected)
-        request = ToolRequest("example", {"value": 1})
-        result = await tool.execute(request)
-        assert tool.requests == [request]
-        return result
+    async def exercise() -> str:
+        tool = FakeTool(build_tool_spec(name="example"), data={"content": "done"})
+        request = build_tool_request(name="example", arguments={"value": 1})
+        prepared = tool.prepare(request)
+        result = await tool.execute(prepared)
+        assert tool.prepare_requests == [request]
+        assert tool.requests == [prepared]
+        assert result.status is ToolStatus.SUCCEEDED
+        return str(result.data["content"])
 
-    assert asyncio.run(exercise()).content == "done"
+    assert asyncio.run(exercise()) == "done"
 
 
 def test_in_memory_store_enforces_contiguous_run_sequences() -> None:

--- a/tests/unit/test_tool_contracts.py
+++ b/tests/unit/test_tool_contracts.py
@@ -1,0 +1,121 @@
+from typing import cast
+
+import pytest
+from pydantic import JsonValue, ValidationError
+from tests.tool_fixtures import build_tool_request, build_tool_spec
+
+from bearagent.domain.errors import ErrorCategory, ErrorCode, ErrorInfo
+from bearagent.domain.tools import (
+    PolicyDecision,
+    PolicyOutcome,
+    PolicyReason,
+    PreparedToolRequest,
+    ToolResult,
+    ToolSpec,
+    ToolStatus,
+)
+
+
+def test_tool_spec_and_request_are_recursively_immutable() -> None:
+    spec = build_tool_spec()
+    request = build_tool_request(arguments={"path": "docs/index.md", "options": {"lines": [1, 2]}})
+
+    with pytest.raises(TypeError):
+        cast(dict[str, JsonValue], spec.input_schema)["new"] = {"type": "string"}
+    options = cast(dict[str, JsonValue], request.arguments["options"])
+    with pytest.raises(TypeError):
+        options["new"] = True
+    assert isinstance(options["lines"], tuple)
+
+
+def test_tool_contracts_round_trip_as_json() -> None:
+    request = build_tool_request()
+    prepared = PreparedToolRequest.model_validate(request.model_dump(mode="json"))
+    result = ToolResult(
+        tool_call_id=request.tool_call_id,
+        status=ToolStatus.SUCCEEDED,
+        data={"content": "BearAgent"},
+    )
+
+    assert PreparedToolRequest.model_validate_json(prepared.model_dump_json()) == prepared
+    assert ToolResult.model_validate_json(result.model_dump_json()) == result
+
+
+def test_tool_spec_rejects_invalid_schema_and_resource_limits() -> None:
+    values = build_tool_spec().model_dump(mode="json")
+    values["input_schema"] = {"type": "array"}
+    with pytest.raises(ValidationError, match="root type must be object"):
+        ToolSpec.model_validate(values)
+
+    values = build_tool_spec().model_dump(mode="json")
+    values["timeout_ms"] = 0
+    with pytest.raises(ValidationError, match="greater than 0"):
+        ToolSpec.model_validate(values)
+
+    values = build_tool_spec().model_dump(mode="json")
+    values["max_input_bytes"] = 1_000_001
+    with pytest.raises(ValidationError, match="less than or equal to 1000000"):
+        ToolSpec.model_validate(values)
+
+    values = build_tool_spec().model_dump(mode="json")
+    values["max_output_bytes"] = 4_000_001
+    with pytest.raises(ValidationError, match="less than or equal to 4000000"):
+        ToolSpec.model_validate(values)
+
+
+def test_tool_request_rejects_non_json_and_oversized_nesting() -> None:
+    with pytest.raises(ValidationError, match="unsupported value"):
+        build_tool_request(arguments={"raw": object()})  # type: ignore[dict-item]
+
+    nested: dict[str, object] = {}
+    cursor = nested
+    for _ in range(34):
+        child: dict[str, object] = {}
+        cursor["child"] = child
+        cursor = child
+    with pytest.raises(ValidationError, match="nesting limit"):
+        build_tool_request(arguments=cast(dict[str, JsonValue], nested))
+
+    with pytest.raises(ValidationError, match="arguments exceed the byte limit"):
+        build_tool_request(arguments={"value": "x" * 1_000_001})
+
+
+def test_tool_result_requires_exactly_one_terminal_shape() -> None:
+    tool_call_id = build_tool_request().tool_call_id
+    error = ErrorInfo(
+        category=ErrorCategory.TOOL,
+        code=ErrorCode.TOOL_ERROR,
+        message="Tool failed.",
+    )
+
+    with pytest.raises(ValidationError, match="successful Tool result cannot contain an error"):
+        ToolResult(
+            tool_call_id=tool_call_id,
+            status=ToolStatus.SUCCEEDED,
+            error=error,
+        )
+    with pytest.raises(ValidationError, match="failed Tool result requires an error"):
+        ToolResult(tool_call_id=tool_call_id, status=ToolStatus.FAILED)
+    with pytest.raises(ValidationError, match="failed Tool result cannot contain data"):
+        ToolResult(
+            tool_call_id=tool_call_id,
+            status=ToolStatus.FAILED,
+            data={"partial": True},
+            error=error,
+        )
+
+
+def test_policy_decision_rejects_mismatched_reason() -> None:
+    assert (
+        PolicyDecision(
+            outcome=PolicyOutcome.ALLOW,
+            reason=PolicyReason.ALLOWED,
+        ).outcome
+        is PolicyOutcome.ALLOW
+    )
+
+    with pytest.raises(ValidationError, match="allow decision requires"):
+        PolicyDecision(
+            outcome=PolicyOutcome.ALLOW,
+            reason=PolicyReason.TOOL_NOT_ALLOWED,
+        )

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from tests.tool_fixtures import build_tool_spec
+
+from bearagent.domain.tools import ToolSideEffect
+from bearagent.ports.tools import Tool
+from bearagent.runtime.tool_registry import ToolRegistry
+
+
+def stub_tool(name: str) -> Tool:
+    return cast(Tool, SimpleNamespace(spec=build_tool_spec(name=name)))
+
+
+def test_registry_resolves_exact_names_in_stable_order() -> None:
+    search = stub_tool("workspace.search")
+    read = stub_tool("workspace.read")
+
+    registry = ToolRegistry([search, read])
+
+    assert [spec.name for spec in registry.specs] == ["workspace.read", "workspace.search"]
+    assert registry.get("workspace.read") is read
+    assert registry.get("Workspace.Read") is None
+    assert registry.get("workspace") is None
+
+
+def test_registry_rejects_duplicate_names() -> None:
+    with pytest.raises(ValueError, match="duplicate Tool name: workspace.read"):
+        ToolRegistry([stub_tool("workspace.read"), stub_tool("workspace.read")])
+
+
+def test_registry_snapshots_the_input_collection() -> None:
+    tools = [stub_tool("workspace.read")]
+    registry = ToolRegistry(tools)
+
+    tools.clear()
+
+    assert registry.get("workspace.read") is not None
+    assert len(registry.specs) == 1
+
+
+def test_registry_snapshots_trusted_spec_before_tool_can_replace_it() -> None:
+    tool = stub_tool("danger.run")
+    tool.spec = build_tool_spec(
+        name="danger.run",
+        side_effect=ToolSideEffect.CODE_EXECUTION,
+    )
+    registry = ToolRegistry([tool])
+
+    tool.spec = build_tool_spec(name="danger.run", side_effect=ToolSideEffect.READ_ONLY)
+
+    registered_spec = registry.get_spec("danger.run")
+    assert registered_spec is not None
+    assert registered_spec.side_effect is ToolSideEffect.CODE_EXECUTION


### PR DESCRIPTION
## What changed

- add bounded, immutable Tool specs, requests, prepared requests, results, Policy decisions, and stable Tool error codes
- add exact-name `ToolRegistry`, default-deny `FixedToolPolicy`, and the single bounded `ToolExecutor` path
- enforce input/output byte limits, timeout handling, cancellation propagation, safe error conversion, and registration-time ToolSpec snapshots
- upgrade the deterministic FakeTool and add unit, contract, integration, and security coverage
- close F-0006 and synchronize architecture, roadmap, README, beginner docs, developer docs, and public status

## Why

F-0004 can translate model function calls into BearAgent data, but the runtime did not yet have one place to verify the Tool name, normalize arguments, apply fixed P1 permissions, and contain timeout or oversized output failures. F-0006 establishes that boundary before real workspace Tools are added.

## User and developer impact

Future F-0007/F-0008 Tools must register through the same Registry, Policy, and Executor path. This PR does not add real file access, Agent Loop wiring, Tool Event persistence, or Run CLI behavior.

## Validation

- `uv lock --check`
- Ruff check and format check
- Pyright: 0 errors
- pytest: 160 passed
- documentation links: 63 Markdown files passed
- Starlight: 26 pages built
- sdist and wheel built; new public imports verified
- `git diff --check`