### PR TITLE
Implement F-0005 Run, inspect, and events CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@
 </div>
 
 > [!IMPORTANT]
-> BearAgent 当前还不能执行真实 Agent 任务。仓库已经实现内部数据类型、Run/Activity 状态、Event
-> Reducer、预算检查、SQLite EventStore、首个 OpenAI Responses adapter、统一 Tool 执行边界、受限
-> workspace 读写工具、原子输出 Artifact 和本地文档站；ContextBuilder、完整 Agent Loop 与 Run CLI
-> 仍在 P1 计划中。
+> BearAgent 已接通本地 `run/inspect/events` CLI、SQLite、OpenAI Responses adapter、受限 workspace
+> Tools 和有界 Agent Loop。自动验证使用 Fake Provider，尚未用真实模型完成 P1 的 4/5 退出演练，
+> 也还没有 P2 的崩溃恢复；因此 P1 仍是进行中。
 
 ## 从一个文件任务说起
 
@@ -45,17 +44,14 @@ BearAgent 不以复刻 Manus、Claude Code 或堆叠模型、工具和 Agent 角
 
 ## 当前状态
 
-| 已有代码 | P1 还要接通 | 更晚再做 |
+| 已有代码 | P1 还要确认/验证 | 更晚再做 |
 |---|---|---|
-| Python 3.12 + uv 工程与 CI | ContextBuilder 和版本化 Agent 配置 | P2：崩溃恢复、Attempt、`UNKNOWN` |
-| `help`、`version`、`doctor` | `run`、`inspect`、`events` | P3：Approval、隔离执行、安全自托管 |
-| 类型化 ID、Message、Error、Event、Artifact | ContextBuilder 和有界 Agent Loop | P4：Skill、MCP、Web、Memory |
-| Run/Activity 状态与五类预算 | ContextBuilder 与有界 Agent Loop | P5：持续追踪与跨版本评测 |
-| SQLite EventStore、projection 与 migration | Tool Activity Event 接线 | P6+：多个 Agent、浏览器、分布式执行 |
-| ModelProvider port 与 OpenAI Responses adapter | 固定任务集与可复现结果 | 只有真实需求出现后再扩展 |
-| Tool Registry、固定 Policy、统一 Executor | Tool Activity Event 接线 | 只有真实需求出现后再扩展 |
-| `workspace.list/read/search/write` 与路径边界 | 文件 Tool 与 Agent Loop 接线 | 只有真实需求出现后再扩展 |
-| 中文 Starlight 文档站 | 端到端固定任务集 | 只有真实需求出现后再扩展 |
+| Python 3.12、uv、CI 与文档站 | 是否把真实模型 API 演练保留为 P1 关闭门 | P2：崩溃恢复、Attempt、`UNKNOWN` |
+| `doctor`、`run`、`inspect`、`events` | 若保留，完成真实模型固定任务 4/5 | P3：Approval、隔离执行、安全自托管 |
+| 类型化领域数据、Reducer 与五类预算 | 完整执行 P1 Reality Check | P4：Skill、MCP、Web、Memory |
+| SQLite EventStore 与 version 1 migration | 核对文档、安装包和失败演练证据 | P5：持续追踪与跨版本评测 |
+| OpenAI adapter、Agent Loop 和 production composition | 不在 F-0005 内读取真实凭据 | P6+：多个 Agent、浏览器、分布式执行 |
+| Registry、固定 Policy 与受限 workspace Tools |  | 只有真实需求出现后再扩展 |
 
 当前事实见[路线图](docs/project/roadmap.md)和[公开状态页](site/src/content/docs/zh-cn/project/status.md)。
 
@@ -70,6 +66,7 @@ uv python install 3.12
 uv sync --all-groups --locked
 uv run bearagent --help
 uv run bearagent doctor
+uv run bearagent run --help
 ```
 
 机器可读诊断：
@@ -78,6 +75,23 @@ uv run bearagent doctor
 uv run bearagent doctor --json
 uv run python -m bearagent doctor --json
 ```
+
+F-0005 的命令入口已经实现：
+
+```powershell
+uv run bearagent run "整理 workspace 中的资料" --profile data/p1-run-profile.json
+uv run bearagent run inspect <run-id> --json
+uv run bearagent run events <run-id> --after-sequence 0 --limit 100 --json
+```
+
+Run profile 只保存非敏感 `AgentConfig` 和预算；API key/base URL 只能来自进程环境。当前仓库只用
+注入式 Fake Provider 自动验证这条链，真实模型配置和 P1 退出演练将在 F-0005 后单独决定。详见
+[从命令行运行并检查一次 Run](site/src/content/docs/zh-cn/learn/run-inspect-events.md)。
+
+[version 1 安全模板](docs/reference/run-profile-v1.example.json)把预算全部设为 0。复制后执行 `run` 会
+保存一个明确的 `budget_exhausted` Run，但不会创建 OpenAI SDK client、读取凭据或调用模型/Tool。只有
+在确认真实 API 演练方案，并填入真实 model、pricing version、费率和非零预算后，才应把它保存为
+`data/p1-run-profile.json`。
 
 ## 开发和验证
 

--- a/docs/adr/ADR-0014-cli-calls-application-production-wiring-stays-in-bootstrap.md
+++ b/docs/adr/ADR-0014-cli-calls-application-production-wiring-stays-in-bootstrap.md
@@ -1,0 +1,119 @@
+---
+title: "ADR-0014: CLI calls application commands while production wiring stays in bootstrap"
+status: accepted
+date: 2026-08-20
+decision_owners: [CherryYang05]
+supersedes: null
+superseded_by: null
+---
+
+# ADR-0014：CLI 只调用 application command，生产依赖只在 bootstrap 组装
+
+## 要解决的问题
+
+F-0005 需要把 `AgentLoop`、OpenAI Responses adapter、SQLite Store、四个 workspace Tool 和固定 Policy
+接到 Typer CLI，还要让 inspect/events 读取同一批事实。最短的写法是让每个 CLI handler 自己创建
+adapter、读取 SQLite 或拼装 JSON；这样执行、查询和未来 HTTP API 会逐渐形成不同业务路径，测试也只能
+通过 Typer 才能调用核心用例。
+
+另一个冲突是配置边界。`AgentConfig` 和预算需要版本化保存，Provider key/base URL 与本机路径却不能
+进入 Event。如果 CLI 把所有参数混成一个自由字典，application 很难分清哪些是可保存事实、哪些只能
+留在 composition root。
+
+现在必须统一三件事：具体 adapter 在哪里创建、执行/查询由哪个模块负责，以及 human/JSON 输出共享
+什么 Provider-neutral 结果。
+
+## 选择时最看重什么
+
+- 可维护性：执行和查询可以脱离 Typer 测试，未来接口不用复制业务规则；
+- 恢复语义：inspect/events 只相信 EventStore 与 Reducer projection，不解析日志或 adapter 状态；
+- 安全：凭据、endpoint、本机绝对路径和原始异常停在最外层，Tool 不能旁路 Policy；
+- 复杂度/交付时间：复用现有 ports 和 Pydantic 类型，不引入 DI framework、服务容器或数据库 ORM；
+- 兼容与迁移：保持现有 AgentLoop、Event v1/v2 和 SQLite schema v1 可读。
+
+## 比较过的方案
+
+### 方案 A：Typer handler 直接组装 adapter 并查询 SQLite
+
+代码最少，命令参数可以直接传给 SDK/SQLite。但 CLI 会同时承担配置、业务协调、SQL、错误转换和展示；
+human/JSON 很容易各查一次，未来 HTTP API 也只能复制同样逻辑。SQLite row、OpenAI client 或 Typer 类型
+还可能进入 application/runtime，破坏现有依赖方向。
+
+### 方案 B：application command 管用例，bootstrap 组装具体 adapter，CLI 只输入和渲染
+
+`bootstrap.py` 是唯一知道 OpenAI、SQLite 和 workspace adapter 的 composition root。application command
+只接收 BearAgent 类型和 ports，执行 AgentLoop 或查询 EventStore，并返回冻结、可序列化的结果。CLI
+只验证系统边界输入、选择 human/JSON renderer 和退出码。代价是增加少量 application DTO/query service
+和组装代码。
+
+### 方案 C：引入服务容器、配置框架或 workflow framework
+
+自动注入和多环境配置会更方便，但 P1 只有一个本地进程、一个 Provider 和一个 CLI。框架不能替代
+BearAgent 自己的 Event、Policy、预算和失败语义，反而增加生命周期与隐式全局状态。
+
+## 决定
+
+选择方案 B，并作出以下约束：
+
+1. `src/bearagent/bootstrap.py` 是生产 composition root。具体 `OpenAIResponsesProvider`、
+   `SqliteEventStore`、workspace Tool、Registry、FixedToolPolicy、ToolExecutor 和 AgentLoop 只能在外层
+   组装；bootstrap 不实现状态、预算、Policy 或查询规则。
+2. `interfaces/cli` 只解析 CLI/profile 输入、调用 application command、渲染 human/JSON 和映射退出码。
+   它不得执行 SQL、直接调用 Tool、解析 Provider SDK response 或从日志推断状态。
+3. application 增加 Provider-neutral Run command/query service。inspect 使用 `EventStore.get_run` 与
+   有界 `list_events`；events 使用同一 port 的分页接口。不存在第二套 projection 或 Artifact 数据库。
+4. application 与 CLI 之间只交换 BearAgent Pydantic 类型，例如 `RunResult`、`RunInspection`、
+   `EventPage` 和安全 command error。JSON schema version 由公开结果定义，human renderer 读取同一对象。
+5. 非敏感运行配置使用严格、有 byte 上限的 version 1 JSON Run profile，内容仅为 `AgentConfig` 和
+   `BudgetLimits`。profile 完整校验后才初始化数据库或 Provider。
+6. API key、可选 base URL、database path 和 workspace root 属于 production configuration，不进入
+   Run profile、AgentConfig 或 Event。CLI 不接受 `--api-key`；Provider 凭据从受信任进程环境注入。
+7. Tool registry 可以包含四个 P1 workspace Tool；profile 的 Tool 名单同时限制模型可见 schema 和
+   FixedToolPolicy allowlist，但不能改变 Policy 对危险 side effect 的硬拒绝。
+8. CLI 保持路线图语法：`bearagent run <objective>` 是 run command group 的无子命令执行路径；同组
+   `inspect/events` 调用 query service。CLI 结构只是接口层规则，不进入 Runtime。
+9. 运行命令可以在最外层预生成 RunId，并传给 AgentLoop，以便在第一次 Provider 调用前让用户看到
+   可查询 ID；不传时 AgentLoop 保持现有内部生成行为。RunId 不由模型或 profile 指定。
+10. 不增加生产依赖、SQLite migration、后台服务、service locator 或可变全局 container。
+11. F-0005 可以组装 ADR-0010 已接受的 OpenAI Responses adapter，但 Feature 验证只注入 Fake Provider，
+    不读取真实凭据、不发起真实模型请求。是否把真实模型演练列为 P1 退出条件，在 F-0005 完成后另议。
+
+## 带来的影响
+
+### 得到的好处
+
+- Fake/真实 Provider、临时/真实 SQLite 都能复用相同 application command 测试；
+- CLI、未来 HTTP API 和开发者 Python 调用可以共享执行/query 结果，不复制 SQL、Reducer 或状态判断；
+- SDK、数据库和文件 adapter 继续停在外层，domain/runtime/application 保持可测试；
+- profile 可以随 RunCreated 保存可复现配置，而凭据和本机路径不会进入 Event；
+- query 可以明确区分 projection、完整 Event payload 和有限 human 摘要。
+
+### 接受的代价
+
+- `bootstrap.py` 从占位文件变成显式组装模块，需要窄接口与集成测试防止它膨胀；
+- CLI 需要独立的 renderer、错误 envelope 和 schema version，公开后不能随意改字段；
+- inspect 为提取 Artifact 需要有界分页读取 Event；超出可信上限时必须失败，而不是返回假完整结果；
+- run command group 的“无子命令执行 + inspect/events 子命令”需要专门 CLI 解析回归测试；
+- profile 是一个额外准备步骤，但它避免硬编码会漂移的模型价格或把大量配置塞进命令历史。
+
+## 迁移和回退
+
+F-0005 不改变 SQLite schema 或 Event payload。已有 v1/v2 数据可直接通过新 query service 读取。CLI
+JSON 在首次发布前可随 draft 调整；发布后不兼容变化使用新 schema version。
+
+回退时移除新 CLI/application/bootstrap 代码和未发布 profile 示例即可。不得删除用户数据库、
+`outputs/**` 或 v2 读取兼容。若 AgentLoop 已增加可选预生成 RunId，回退 CLI 时可保留这个兼容参数；
+它不改变已保存 Event 语义。
+
+## 怎样验证
+
+- application command 使用 Fake Provider/InMemory Store 与 Fake Provider/SQLite 独立于 Typer 运行；
+- CLI integration 证明 human/JSON 调用同一 command result，且每个 JSON stdout 只有一个对象；
+- import boundary 测试禁止 domain/runtime/application 导入 Typer、OpenAI、SQLite 和 workspace adapter；
+- spy/fixture 证明 CLI/bootstrapping 不直接执行 Tool，所有文件动作经过 FixedToolPolicy + ToolExecutor；
+- query tests 证明只调用 EventStore port、分页有界、缺失/损坏数据安全失败，不执行自定义 SQL；
+- profile/错误输出扫描确认 key、authorization、base URL、本机绝对路径和原始异常没有进入 Event/JSON；
+- console script、`python -m bearagent`、wheel import 和 Windows/Ubuntu 测试通过；
+- 项目所有者接受本决定后，F-0005 Plan 才能激活并开始实现。
+
+项目所有者于 2026-08-20 接受本决定，并明确把真实模型 API/演练留到 F-0005 完成后讨论。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,8 @@ ADR 只记录影响多个模块、以后难以反转的技术决定。标题直�
   — accepted
 - [ADR-0013：P1 Agent Loop 串行执行，并在外部调用前后保存 Activity 事实](ADR-0013-serial-agent-loop-event-boundaries.md)
   — accepted
+- [ADR-0014：CLI 只调用 application command，生产依赖只在 bootstrap 组装](ADR-0014-cli-calls-application-production-wiring-stays-in-bootstrap.md)
+  — accepted
 
 新决定使用 [ADR 模板](../templates/adr.md)。被新决定替代的 ADR 不删除，改为 `superseded` 并链接
 到替代它的文档。

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,8 +1,8 @@
 ---
 title: BearAgent Architecture Baseline
 status: accepted
-version: 0.7
-last_verified: 2026-08-18
+version: 0.8
+last_verified: 2026-08-20
 ---
 
 # BearAgent 总体架构
@@ -53,17 +53,18 @@ flowchart TB
 | workspace 输出边界 | `outputs/**` UTF-8 原子创建/替换、Artifact 元数据和失败前旧目标保护 |
 | Agent 执行链 | 从已提交 Event 构造有界 Context，串行调用模型与 Tool，并把 v2 Activity 事实写回 Store |
 | 固定任务 | 五个版本化文件任务在内存和 SQLite Store 上使用 Fake Provider 完成确定性验证 |
+| 用户入口 | `run/inspect/events` CLI、严格 Run profile、human/JSON renderer 和安全退出码 |
+| 查询 | application query service 只通过 EventStore 读取 projection 与分页 Event，并重建 Artifact 元数据 |
 | 测试替身 | Fake model、Fake tool、内存 Event store |
 | 文档 | 工程 `docs/` 与本地 Starlight 学习/开发者站点 |
 
-当前 application 层的 `AgentLoop` 已把 EventStore、ContextBuilder、ModelProvider 和 ToolExecutor 接成
-串行执行链。测试可用 Fake Provider 配合真实 workspace Tool，在内存或 SQLite Store 中完成文件任务。
-F-0005 尚未组装生产 CLI，因此用户还不能从命令行启动真实模型任务；持久事实也仍不等于进程重启后
-会自动继续。
+`bootstrap.py` 已把 OpenAI adapter、SQLite、workspace Tools、固定 Policy 和 AgentLoop 组装到同一
+生产入口。F-0005 测试注入 Fake Provider，让五个固定任务走这条 production composition，并重开
+SQLite 检查 `inspect/events`。真实模型 API 尚未做退出演练；持久事实也仍不等于进程重启后会自动继续。
 
 ### 3.2 已接受但尚未接通
 
-- P1：Run CLI、inspect/events 查询和真实模型退出演练；
+- P1：决定并执行真实模型 API/4-of-5 gate（若保留），再完成整个里程碑 Reality Check；
 - P2：Checkpoint、Attempt、暂停/继续/取消、恢复协调和 `UNKNOWN` 处置；
 - P3：Grant、Policy、Approval、隔离 runner、HTTP API、认证和备份恢复；
 - P4：Skill、MCP、Web UI、Memory 和受控联网；
@@ -237,8 +238,11 @@ BearAgent 不承诺任意外部 API exactly-once，也不假装可以从任意 P
 
 F-0004 已实现首个 OpenAI Responses 流式 adapter，并使用确定性替代实现与契约测试约束内部接口。
 SDK 自动重试被禁用，工具调用参数必须是有界 JSON object，流中只有文本增量、完整工具调用和唯一
-完成事件可以进入 Runtime。F-0016 的 AgentLoop 已通过该 port 调度模型，但生产 OpenAI adapter 与
-CLI 的组装仍属于 F-0005；第二个生产 adapter 出现时，需要运行同一组模型行为测试。
+完成事件可以进入 Runtime。F-0016 的 AgentLoop 已通过该 port 调度模型，F-0005 又在
+`bootstrap.py` 把首个生产 adapter 接到 CLI。OpenAI SDK client 延迟到首个模型 Activity 真正开始时
+创建；零预算 Run 因此先保存 `budget_exhausted`，缺少凭据则保存安全的
+`provider_authentication`，而不是在 composition 阶段丢失 Run。自动测试始终注入 Fake Provider，
+没有读取真实 key 或发出真实模型请求；第二个生产 adapter 出现时，需要运行同一组模型行为测试。
 
 参数错误、权限错误和上下文超限不能盲目重试。只有明确的临时错误允许有限重试。
 
@@ -359,7 +363,14 @@ bearagent run events <run_id>
 bearagent doctor
 ```
 
-人类可读输出与 `--json` 调用同一 application command，不复制业务逻辑。
+`run` 默认读取当前目录作为 workspace、`data/p1-run-profile.json` 和 `data/bearagent.db`，也允许用
+显式选项覆盖。profile 只有 versioned AgentConfig 和 BudgetLimits；Provider key/base URL 只从环境
+注入。人类可读输出与 `--json` 使用同一个 application result，不复制查询或状态规则。
+
+`inspect` 返回 Reducer projection 和从已提交 v2 Tool Event 重建的 Artifact。`events` 使用有界页、
+sequence cursor 和 `has_more`；默认 human 输出不打印 payload，显式 `--json` 才导出完整 Event。查询
+只调用 EventStore port，数据库不存在时不会创建空库。进程中断后的非终态 Run 会原样显示，不会
+自动恢复或伪造 terminal 状态。
 
 ### 13.2 P3 HTTP/SSE
 

--- a/docs/deployment/self-hosting.md
+++ b/docs/deployment/self-hosting.md
@@ -1,8 +1,8 @@
 ---
 title: Local-first and Self-hosting Strategy
 status: accepted
-version: 0.4
-last_verified: 2026-08-13
+version: 0.5
+last_verified: 2026-08-20
 ---
 
 # 本地开发与自托管
@@ -42,6 +42,19 @@ Production  P3 安全门通过后才启用公网 hostname
 - 不开放 HTTP，不提供 host shell；
 - secret 只在本机环境或 secret store；
 - 文档站本地预览和 CI 构建，不部署。
+
+F-0005 的本地 CLI 默认使用当前目录作为 workspace、`data/p1-run-profile.json` 作为非敏感配置、
+`data/bearagent.db` 作为 EventStore。profile 只含 AgentConfig 与预算，不允许 API key、base URL 或本机
+路径。OpenAI adapter 由 SDK 从 `OPENAI_API_KEY` 和可选 `OPENAI_BASE_URL` 读取环境；这些值不进入
+Event。SDK client 只在首个模型 Activity 开始时创建；凭据缺失会成为持久的
+`provider_authentication` Run failure。自动测试注入 Fake Provider，尚未授权或完成真实模型演练。
+
+仓库中的 [`run-profile-v1.example.json`](../reference/run-profile-v1.example.json) 是 fail-closed 结构
+模板：所有预算为 0，model/pricing 是占位值。它允许 CLI 保存一个 `budget_exhausted` Run，但不会创建
+SDK client 或调用模型/Tool。未确认真实 API 演练方案前，不要把它改成会发起调用的配置。
+
+`run inspect/events` 只打开已经存在的普通数据库文件。不存在的路径不会生成空数据库；损坏或未来
+migration 只返回安全 persistence Error。这里仍是本地命令，不会启动 HTTP 服务。
 
 ### P1 完成后：公开静态文档
 

--- a/docs/plans/PLAN-F-0005-run-inspect-events-cli.md
+++ b/docs/plans/PLAN-F-0005-run-inspect-events-cli.md
@@ -1,0 +1,180 @@
+---
+title: "Implementation Plan: Production Run, inspect, and Event CLI"
+status: completed
+plan_id: PLAN-F-0005
+related_spec: F-0005
+created: 2026-08-20
+last_updated: 2026-08-20
+---
+
+# PLAN-F-0005：接通生产 Run、inspect 和 events CLI
+
+关联 Spec：`docs/specs/F-0005-run-inspect-events-cli.md`
+
+## 开始前确认
+
+- [x] F-0005 Spec 已由项目所有者接受，并把 status 从 `draft` 改为 `accepted`；
+- [x] ADR-0014 已由项目所有者接受，并把 status 从 `proposed` 改为 `accepted`；
+- [x] Spec 第 16 节四项决定均已确认，没有影响实现的开放问题；
+- [x] F-0016 已合入 `main`，当前分支从 `main@2b0e90a` 创建；
+- [x] 仓库当前没有其他 `active` 主 Plan；
+- [x] 以上条件满足，本 Plan 于 2026-08-20 从 `draft` 改为 `active`。
+
+## 实施步骤
+
+### 第 1 步：冻结 Run query 与 CLI JSON 结果契约
+
+Status：completed（2026-08-20）。
+
+- 交付结果：新增严格、冻结、Provider-neutral 的 `RunInspection`、`EventPage`、version 1 CLI result/error
+  envelope；定义 UUID、时间、Enum、Event payload、Artifact 和 pagination 的 JSON shape；
+- 代码落点：`src/bearagent/domain/` 放可复用 query 结果，`src/bearagent/interfaces/cli/contracts.py` 放
+  CLI envelope；分别维护公共 Schema/快照和对应 unit/contract tests；
+- 接入关系：EventStore 继续只返回 `RunState/Event`；application 组合 query result；CLI 只渲染；
+- 重点测试：[AC-3][AC-4][AC-6] 未知字段、冻结、JSON round-trip、稳定 schema、游标、Artifact 去重/顺序；
+- 验证命令：`uv run pytest tests/unit/test_run_queries.py tests/contract/test_cli_schemas.py tests/contract/test_domain_schemas.py`；
+- 回退方式：删除尚未接入 CLI 的 query/output 类型并恢复 Schema 快照，不修改 Event 或数据库。
+
+### 第 2 步：实现只依赖 EventStore 的 application query service
+
+Status：completed（2026-08-20）。
+
+- 交付结果：`inspect` 从 projection 加有界 Event 分页构造完整结果；`events` 返回有界页、下一游标和
+  `has_more`；缺失 Run、超量、解析/corruption 均返回安全 application error；
+- 代码落点：`src/bearagent/application/run_queries.py`、application exports 和 unit tests；
+- 接入关系：service 只依赖 EventStore port 和领域解析函数；不导入 SQLite、Typer、Provider 或 workspace；
+- 重点测试：[AC-3][AC-4][AC-5] 非终态、terminal Error、Artifact、边界页、空页、超上限、Store failure；
+- 验证命令：`uv run pytest tests/unit/test_run_queries.py tests/contract/test_event_store_contract.py`；
+- 回退方式：移除 query service；已有 Store port、Event 和 projection 保持不变。
+
+### 第 3 步：建立有界 Run profile 和唯一 production composition root
+
+Status：completed（2026-08-20）。
+
+- 交付结果：严格读取 version 1 JSON profile，先完成大小/UTF-8/字段/领域校验，再组装 SQLite、OpenAI、
+  workspace Tools、Registry、FixedToolPolicy、ToolExecutor、AgentLoop 和 query service；支持可信层预生成
+  RunId 供 CLI 提前显示；OpenAI SDK client 延迟到首个真实模型 Activity，零预算和缺凭据因此都保留为
+  可查询的安全 terminal Run；
+- 代码落点：`src/bearagent/bootstrap.py`、必要的 application facade/AgentLoop 兼容参数、profile 示例或
+  generated reference，以及 unit/integration/security tests；
+- 接入关系：bootstrap 可以导入具体 adapter；application/runtime/domain 继续只依赖 ports/BearAgent 类型；
+- 重点测试：[AC-1][AC-7][AC-8] profile 未知/敏感字段、超限/非法 UTF-8、缺失 key、路径、Policy allowlist、
+  预生成 ID、初始化顺序、零外部调用；
+- 验证命令：`uv run pytest tests/unit/test_bootstrap.py tests/integration/test_run_cli.py tests/security/test_cli_boundaries.py tests/architecture/test_import_boundaries.py`；
+- 回退方式：移除 composition/profile；可选 RunId 参数保持兼容或一并回退，不触碰数据库/Artifact。
+
+### 第 4 步：接通 Typer run/inspect/events 和 human/JSON renderer
+
+Status：completed（2026-08-20）。
+
+- 交付结果：在现有 `doctor` 旁增加 run command group；无子命令执行 objective，inspect/events 调用 query
+  service；human 输出有限清楚，JSON stdout 单对象；退出码稳定；
+- 代码落点：`src/bearagent/interfaces/cli/`、`tests/unit/test_cli.py` 和新的 CLI integration tests；
+- 接入关系：handler 只调用 application/bootstrap 暴露的窄接口；renderer 不查询 Store、不调用 adapter；
+- 重点测试：[AC-1][AC-2][AC-3][AC-4][AC-6][AC-10] help/解析歧义、human/JSON、stderr、not found、
+  failed/non-terminal Run、module/console entrypoint；
+- 验证命令：`uv run pytest tests/unit/test_cli.py tests/integration/test_run_cli.py tests/integration/test_module_entrypoint.py`；
+- 回退方式：移除新命令与 renderer，保留 `doctor/version`；application/query 可独立保留或随后回退。
+
+### 第 5 步：验证中断、安全边界和安装包
+
+Status：completed（2026-08-20）。
+
+- 交付结果：故障注入覆盖 Run 创建、Activity、terminal append、Ctrl+C、外部写后 append 失败；查询重开
+  SQLite 后只显示已提交事实；secret/路径/SQL/SDK 异常不泄漏；wheel 中入口可运行；
+- 代码落点：`tests/recovery/`、`tests/security/`、`tests/integration/`、architecture/package verification；
+- 接入关系：测试从 CLI/application 入口进入，外部文件动作仍通过 ToolExecutor，查询只通过 EventStore；
+- 重点测试：[AC-2][AC-5][AC-7][AC-8][AC-9][AC-10] append failure、active Run、损坏/未来 DB、broken pipe、
+  Prompt/profile 提权、console script/wheel；
+- 验证命令：`uv run pytest tests/recovery tests/security tests/integration tests/architecture`；
+- 回退方式：移除测试 seam 与 F-0005 实现；不删除已产生数据库或 `outputs/**`。
+
+### 第 6 步：运行固定任务、同步四个文档表面并交付 P1 收尾检查点
+
+Status：completed（2026-08-20）。
+
+- 交付结果：Fake Provider 5/5 持续通过；production composition 测试通过注入 Fake Provider 完成，不
+  读取真实凭据或发起真实模型请求；完成独立反向审查和完整验证；
+- 代码落点：`evals/p1/` 的复用 runner/结果说明、相关 `docs/`、README、
+  `site/src/content/docs/zh-cn/learn/`、`development/`、`project/status.md` 和索引；
+- 接入关系：离线验证复用 F-0016 task 定义与 F-0005 production composition，不建立第二套 Prompt/Tool；
+- 重点测试：[AC-11][AC-12] exact task/profile/model version、Tool 路径、Artifact hash、文档链接、站点、
+  Schema、build、wheel 和 Reality Check 清单；
+- 验证命令：运行本 Plan 的最终验证；不读取真实凭据、不运行真实模型；
+- 回退方式：F-0005 gate 未通过时保持 Feature/P1 未关闭；通过后只关闭 F-0005，P1 保持进行中，等待
+  真实模型 API/演练决定和完整 Reality Check。
+
+## 耦合评估
+
+- 新增/修改公共接口：Provider-neutral query/output 模型、application query service、AgentLoop 可选可信
+  RunId、CLI command/JSON schema 和 Run profile schema；
+- 依赖模块：interfaces 依赖 application/bootstrap；bootstrap 组装 adapters + application；application 只依赖
+  domain/runtime/ports；
+- 新依赖：无；继续使用 Typer、Pydantic、OpenAI SDK、SQLite stdlib 和现有 uv 工具链；
+- 依赖方向：不允许 domain/runtime/application 导入 Typer、OpenAI SDK、SQLite adapter 或 workspace adapter；
+- 循环风险：profile loader/renderer 不进入 application；bootstrap 不被 core 导入；query service 不回调 CLI；
+- 扇出控制：CLI 参数、human renderer、JSON renderer、profile loader、production composition 和 query service
+  分开；`main.py` 不变成同时负责 SQL/Provider/Tool/输出的上帝文件。
+
+## 关键注释原则
+
+- 在 production composition 说明为什么 key/path 不能进入 AgentConfig/Event；
+- 在 inspect 的总量上限处说明为什么宁可明确失败，也不能返回假完整 Artifact；
+- 在预生成 RunId 处说明 ID 是可信 composition 输入，不是模型/profile 权限；
+- 在 Event JSON renderer 说明完整 payload 是显式导出，不是默认日志；
+- 不给直接委托、字段映射或显而易见的 Typer 装饰器增加冗余注释。
+
+## 每一步都要检查
+
+- [x] Event/Run projection 语义未复制或分叉，SQLite schema/migration 未改变；
+- [x] inspect/events 只读取已提交事实，非终态 Run 不显示成功；
+- [x] 所有 workspace 动作继续经过 Registry、prepare、FixedToolPolicy 和 ToolExecutor；
+- [x] profile、CLI、Event query 和 renderer 均有大小/数量/timeout 边界；
+- [x] API key、authorization、base URL、本机绝对根、SQL 和原始异常不进入 Event/输出；
+- [x] Ctrl+C/强制退出不自动 retry/resume，不伪造 terminal 或 `UNKNOWN`；
+- [x] human/JSON 共享 application result，JSON stdout 保持单对象；
+- [x] domain/runtime/application 没有外层 adapter/SDK/CLI 类型泄漏；
+- [x] AC 编号与 Plan 步骤、测试和文档回链；
+- [x] 工程文档、初学者路径、开发者文档、当前状态和 P1 milestone 同步。
+
+## 最终验证
+
+```powershell
+$env:UV_CACHE_DIR='D:\BearAgent\.uv-cache'
+uv lock --check
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+uv run python scripts/generate_domain_schemas.py
+uv run python scripts/generate_cli_schemas.py
+uv run python scripts/check_docs.py
+npm.cmd run build --prefix=site
+uv build
+uv run --isolated --no-project --with .\dist\bearagent-0.1.0-py3-none-any.whl bearagent doctor --json
+uv run --directory .\dist --isolated --no-project --with .\bearagent-0.1.0-py3-none-any.whl python ..\scripts\smoke_wheel_cli.py
+git diff --check
+```
+
+还要从构建出的 wheel 在隔离目录运行 `bearagent doctor`、Fake CLI Run、inspect/events JSON，并确认
+console script 与 `python -m bearagent` 一致。本 Feature 的验证不得读取真实凭据或调用真实模型；
+F-0005 完成后再向项目所有者提交 P1 真实模型 API/演练与完整 Reality Check 的单独决定。
+
+以上命令没有实际通过前，不得把 Plan 标记为 `completed` 或把 Spec 标记为 `implemented`。F-0005
+完成也不得自动把 Roadmap/P1 状态写成已完成。
+
+## 完成证据
+
+2026-08-20 完成离线验收：uv lock、Ruff format/check、Pyright 和 348 项 pytest 全部通过；公共
+domain/CLI Schema 重新生成后 hash 不变；89 份 Markdown 的本地链接通过；Starlight 成功构建 34 个
+页面；sdist/wheel 构建成功。隔离安装后的 console script、`python -m bearagent`、Fake Provider
+`run/inspect/events` smoke test 均通过。pytest 使用同一组仓库本地临时/cache 目录完成，验收后清理，
+不保留按步骤递增的测试目录。
+
+验收没有读取真实 Provider 凭据或调用真实模型。F-0005 在此关闭；Roadmap/P1 保持进行中，等待项目
+所有者决定真实模型 API/4-of-5 gate，并执行完整 P1 Reality Check。
+
+同日收尾复查补充了 Provider 初始化边界：SDK client 不再在 bootstrap 阶段抢先读取凭据。新增回归
+测试分别证明零预算 Run 在任何 Provider client 创建前以 `budget_exhausted` 持久终止，以及非零预算但
+缺少凭据时以安全的 `provider_authentication` 持久终止；Fake Provider 仍只通过测试注入，不进入生产
+CLI 选项。最终测试数量和完整验证证据以本分支交付摘要为准。

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -18,7 +18,7 @@ Plan 不重复 Spec 的需求，也不代替 ADR。开始前确认 Spec 已 `acc
 
 ## 当前计划
 
-当前没有 active 主 Plan。
+当前没有 active 主 Plan。P1 的真实模型 API/演练和 Reality Check 将在 F-0005 后单独确认。
 
 ## 已完成计划
 
@@ -31,3 +31,4 @@ Plan 不重复 Spec 的需求，也不代替 ADR。开始前确认 Spec 已 `acc
 - [PLAN-F-0008：实现 outputs 原子写入和 Artifact 元数据](PLAN-F-0008-atomic-output-artifacts.md)
 - [PLAN-F-0015：本地 Starlight 文档站](PLAN-F-0015-local-starlight-docs-site.md)
 - [PLAN-F-0016：实现有界 Context 和串行 Agent Loop](PLAN-F-0016-bounded-context-agent-loop.md)
+- [PLAN-F-0005：接通生产 Run、inspect 和 events CLI](PLAN-F-0005-run-inspect-events-cli.md)

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -1,8 +1,8 @@
 ---
 title: BearAgent Roadmap
 status: accepted
-version: 0.8
-last_verified: 2026-08-17
+version: 0.9
+last_verified: 2026-08-20
 ---
 
 # BearAgent 项目路线图
@@ -67,8 +67,9 @@ Feature 可以根据 Spec、Plan、测试和文档流程推进。
 
 ## 5. P1：可检查执行
 
-**状态：进行中（2026-08-10 开始）。** F-0001、F-0002、F-0003、F-0004、F-0006、F-0007、F-0008、
-F-0015 和 F-0016 已实现。P1 还需由 F-0005 接通 CLI、查询入口和真实模型退出演练。
+**状态：进行中（2026-08-10 开始）。** F-0001 至 F-0008、F-0015 和 F-0016 已实现。F-0005 已接通
+CLI、production composition 和查询入口。P1 仍需单独决定真实模型 API/4-of-5 gate，并完成整个
+里程碑 Reality Check；F-0005 完成不会自动关闭 P1。
 
 ### 5.1 用户结果
 
@@ -112,8 +113,9 @@ F-0003 已完成 EventStore port、SQLite adapter、schema v1 和 projection。�
 P1 不做自动摘要 Memory 或复杂上下文压缩。
 
 F-0004 已完成 Provider-neutral 模型数据与 port、确定性测试 adapter 和首个 OpenAI Responses 流式
-adapter。F-0016 已由 ContextBuilder 和 AgentLoop 调用该 port；生产 adapter 与 CLI 的组装仍未完成，
-因此还不等于用户已经能运行真实任务。
+adapter。F-0016 已由 ContextBuilder 和 AgentLoop 调用该 port；F-0005 已在 `bootstrap.py` 组装生产
+adapter、SQLite、Policy 和 workspace Tools。当前自动证据仍来自 Fake Provider，不代表真实模型 gate
+已经通过。
 
 #### 受限文件工具
 
@@ -135,11 +137,13 @@ ToolExecutor 的记录式入口，并把原始/规范化请求、Policy 决定�
 - `bearagent run` 启动 Run，并输出模型文本、Tool 状态和最终 Artifact；
 - `run inspect` 显示状态、预算、usage、Error 和 Artifact；
 - `run events` 按 sequence 输出事实；
-- 人类输出与 `--json` 调用同一 application command；
- - 固定任务集记录任务版本、模型、Prompt、Tool 版本、预算、结果和执行路径。
+- 人类输出与 `--json` 调用同一 application result；
+- 固定任务集记录任务版本、模型、Prompt、Tool 版本、预算、结果和执行路径。
 
-F-0016 已交付五个版本化 Fake Provider 任务，并在内存/SQLite Store 上验证 5/5。本节剩余工作是
-F-0005 的 CLI、查询输出和真实模型演练。
+F-0016 已交付五个版本化 Fake Provider 任务，并在内存/SQLite Store 上验证 5/5。F-0005 让相同任务
+再通过 production composition、真实 SQLite 和 workspace Tools 验证 5/5，并接通 CLI/query 输出。
+OpenAI SDK client 只在首个模型 Activity 开始时创建，因此零预算和缺少凭据都会留下明确、可查询的
+terminal Run。真实模型演练不是 F-0005 的完成门，留给 Feature 后的 P1 决定。
 
 ### 5.3 P1 明确不做
 
@@ -159,7 +163,7 @@ F-0005 的 CLI、查询输出和真实模型演练。
 6. [F-0008：`outputs/**` 原子写和 Artifact](../specs/F-0008-atomic-output-artifacts.md)——已实现；
 7. [F-0016：ContextBuilder、有界 Loop、版本化 Agent 配置和任务集](../specs/F-0016-bounded-context-agent-loop.md)
    ——已实现；
-8. F-0005：`run/inspect/events` CLI 与端到端演示。
+8. [F-0005：`run/inspect/events` CLI 与端到端演示](../specs/F-0005-run-inspect-events-cli.md)——已实现。
 
 每次只激活一个主 Feature。可以根据依赖调整顺序，但不能并行铺开整个 Backlog。
 
@@ -348,7 +352,7 @@ Feature ID 在全项目稳定。未创建 Spec 的名称只表示计划范围；
 6. [F-0008：原子写和 Artifact](../specs/F-0008-atomic-output-artifacts.md) — implemented
 7. [F-0004：模型接口和首个真实 adapter](../specs/F-0004-model-provider-first-adapter.md) — implemented
 8. [F-0016：ContextBuilder、有界 Loop、Agent 配置和评测任务](../specs/F-0016-bounded-context-agent-loop.md) — implemented
-9. F-0005：`run/inspect/events` CLI
+9. [F-0005：`run/inspect/events` CLI](../specs/F-0005-run-inspect-events-cli.md) — implemented
 10. [F-0015：本地 Starlight 文档站](../specs/F-0015-local-starlight-docs-site.md) — implemented
 
 ### P2

--- a/docs/reference/run-profile-v1.example.json
+++ b/docs/reference/run-profile-v1.example.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "agent_config": {
+    "agent_id": "local-file-agent",
+    "agent_version": "p1-v1",
+    "instructions": "Use only the configured workspace Tools. Write requested results below outputs/.",
+    "model": "replace-with-provider-model",
+    "prompt_version": "p1-v1",
+    "context_version": "p1-v1",
+    "max_output_tokens": 1024,
+    "model_timeout_ms": 30000,
+    "max_context_chars": 524288,
+    "max_tool_result_bytes": 65536,
+    "tool_names": [
+      "workspace.list",
+      "workspace.read",
+      "workspace.search",
+      "workspace.write"
+    ],
+    "pricing": {
+      "version": "replace-with-pricing-version",
+      "input_microusd_per_million_tokens": 0,
+      "output_microusd_per_million_tokens": 0
+    }
+  },
+  "budget_limits": {
+    "max_model_iterations": 0,
+    "max_tokens": 0,
+    "max_cost_microusd": 0,
+    "max_wall_time_ms": 0,
+    "max_tool_calls": 0
+  }
+}

--- a/docs/specs/F-0005-run-inspect-events-cli.md
+++ b/docs/specs/F-0005-run-inspect-events-cli.md
@@ -1,0 +1,276 @@
+---
+title: "Feature: Production Run, inspect, and Event CLI"
+status: implemented
+spec_id: F-0005
+milestone: P1
+owner: CherryYang05
+created: 2026-08-20
+last_updated: 2026-08-20
+implemented_in: "codex/F-0005-cli-run-inspect-events"
+related_adrs: [ADR-0003, ADR-0004, ADR-0009, ADR-0010, ADR-0013, ADR-0014]
+---
+
+# F-0005：从命令行运行文件任务，并查看同一批已保存事实
+
+## 1. 为什么现在要做
+
+用户已经可以在 Python 测试中让 `AgentLoop` 调用真实 workspace Tool，并把每次模型和 Tool Activity
+保存到内存或 SQLite Store。可是当前命令行只有 `doctor`。用户还不能组装真实 Provider、SQLite、
+workspace 和固定 Policy，也不能在进程退出后查看已经提交的 Run。
+
+F-0005 负责接通最后一段 P1 用户路径：用户在终端启动文件任务，得到 Run ID、终态文本和 Artifact；
+随后用同一个 SQLite 数据库查看 projection 和有序 Event。CLI 不再维护另一份状态，也不直接读取
+SQLite 表。
+
+## 2. 本次交付
+
+- G-1：`bearagent run <objective>` 通过生产组装运行一个受限本地文件任务；
+- G-2：`bearagent run inspect <run_id>` 显示状态、预算、usage、Activity、Error 和 Artifact；
+- G-3：`bearagent run events <run_id>` 分页显示该 Run 已提交的有序 Event；
+- G-4：人类输出和 `--json` 使用同一 application command 结果，JSON 具有稳定版本；
+- G-5：真实 Provider、SQLite、workspace Tool 和固定 Policy 只在 composition root 组装；
+- G-6：复用 F-0016 的五个固定任务，以注入式 Fake Provider 验证 production-compatible CLI 组装；
+- G-7：完成 Feature 的工程文档、学习路径、开发者文档与公开状态同步，并保留 P1 收尾决定入口。
+
+## 3. 本次不做
+
+- NG-1：不增加 Checkpoint、启动恢复、pause/resume/cancel/retry、Attempt、Receipt 或 `UNKNOWN`；
+- NG-2：不增加 Approval、Grant、sandbox、shell、代码执行、任意网络 Tool、HTTP API 或 Web UI；
+- NG-3：不增加 Run 列表、删除、导出、全文搜索、交互式聊天或后台 daemon；
+- NG-4：不增加第二个生产 Provider，不把 OpenAI SDK 类型暴露给 application 或 CLI；
+- NG-5：不增加数据库 migration、Artifact 表或第二份 CLI 状态库；
+- NG-6：不调用真实模型 API，也不把真实模型 4/5 设为本 Feature 的完成门槛；是否把它纳入 P1
+  退出条件，等 F-0005 完成后由项目所有者另行决定；
+- NG-7：不实时持久化 token delta，也不承诺进程中断后自动继续。
+
+## 4. 需要先说明的约定
+
+### Run profile 是可复现配置，不是密钥或权限
+
+`bearagent run` 读取一个有大小上限、拒绝未知字段的 JSON Run profile。profile schema version 1 包含
+现有 `AgentConfig` 和 `BudgetLimits`，因此模型、Prompt、Context、Tool 名单、定价和五类预算会随
+`RunCreated` v2 Event 保存。
+
+profile 不包含 API key、base URL、workspace 绝对路径或数据库路径。Provider 凭据和可选 endpoint
+只从受信任进程环境注入；profile 中的 Tool 名单只能缩小暴露范围，不能绕过固定 Policy。
+
+### inspect 是 projection 加 Event 证据，不是重新执行
+
+`run inspect` 先通过 `EventStore.get_run` 取得 Reducer projection，再通过有界分页读取同一 Run 的
+Event，提取已经保存的 Artifact 元数据。它不调用模型或 Tool，不解析日志，也不直接查询 SQLite 表。
+
+### `--json` 是一个完整对象
+
+每个命令的 JSON stdout 恰好包含一个 schema version 1 对象。进度和诊断只写 stderr，避免破坏机器
+读取。`run events --json` 明确返回 Event payload；其中可能包含用户目标、模型输出和 ToolResult，
+调用者应把它当作本地执行记录处理，而不是无敏感内容的日志摘要。
+
+## 5. 使用场景
+
+### 5.1 运行一个文件任务
+
+用户准备非敏感 Run profile，并在环境中设置 Provider 凭据。用户指定 workspace、数据库和目标后，
+CLI 初始化 SQLite，组装四个 workspace Tool、固定 Policy、OpenAI Responses adapter 和 `AgentLoop`。
+人类输出在第一次 Provider 调用前给出 Run ID；终止时显示状态、模型文本、各 Tool Activity 和 Artifact
+路径/hash。JSON 输出返回同一 `RunResult` 的稳定结构。
+
+### 5.2 进程退出后检查事实
+
+进程在一次模型或 Tool Activity 中退出。用户以先前显示的 Run ID 执行 `run inspect`。命令显示
+`running` 和最后一个 PENDING/RUNNING Activity，而不是猜测成功。`run events` 仍能列出退出前已经提交
+的 requested/started Event。
+
+### 5.3 分页查看 Event
+
+用户执行 `run events <run_id> --after-sequence 30 --limit 20 --json`。application command 校验参数，
+调用 EventStore 的有界查询，并返回 sequence 31 开始的一页、下一游标和是否还有后续事实。
+
+## 6. 必须满足的行为
+
+### 6.1 Run 创建和生产组装
+
+- FR-1：命令结构固定为 `bearagent run <objective>`、`bearagent run inspect <run_id>` 和
+  `bearagent run events <run_id>`；三者均支持 `--json`；
+- FR-2：执行命令默认使用当前目录作为 workspace、`data/bearagent.db` 作为 SQLite database、
+  `data/p1-run-profile.json` 作为 version 1 Run profile，并允许分别用显式选项覆盖；workspace 必须是
+  已有普通目录，profile 必须是有限 UTF-8 JSON 普通文件；
+- FR-3：profile 只允许 `schema_version`、`agent_config` 和 `budget_limits`，并复用现有严格领域校验；
+  API key、authorization、base URL、database 或 workspace root 出现在 profile 时必须因未知字段被拒绝；
+- FR-4：生产 composition root 初始化 `SqliteEventStore`，创建 `OpenAIResponsesProvider` adapter，用
+  同一个 `WorkspaceBoundary` 构造四个 workspace Tool，并以 profile 的 Tool 名单建立
+  `FixedToolPolicy` 和 `ToolExecutor`；OpenAI SDK client 只在首个模型 Activity 开始时创建，模型不能改变
+  这些对象；
+- FR-5：CLI 在调用 Provider 前生成并显示 Run ID，再由 AgentLoop 使用该 ID 创建 Run；现有 Python
+  调用不传 ID 时继续由 Loop 生成，不破坏 F-0016 用法；
+- FR-6：执行结果只来自 `RunResult` 和已提交 `RunState`。成功时退出码为 0；Run 以 `failed` 终止或
+  production boundary 安全失败时退出码为 1；Typer 用法错误保持退出码 2；
+- FR-7：人类成功输出至少包含 Run ID、终态、最终模型文本、预算用量、Tool Activity 状态和每个
+  Artifact 的规范化相对路径、字节数与 SHA-256；失败输出包含安全 Error，不打印原始异常；
+- FR-8：`--json` stdout 只输出一个版本化结果对象。允许把 Run ID 和有限进度写入 stderr；不得把
+  token delta、Provider 原始响应或完整 ToolResult 作为隐式日志输出。
+
+### 6.2 inspect 和 events 查询
+
+- FR-9：查询命令只通过 application query service 使用 `EventStore` port；不得导入 `sqlite3`、执行
+  SQL、读取 projection row 或复制 Reducer；
+- FR-10：`run inspect` 返回完整 `RunState`、终态 Error、预算 limits/usage、Activity 和从已提交 v2
+  Tool completed Event 提取的 Artifact；非终态 Run 原样显示 `queued/running`；
+- FR-11：inspect 的 Event 扫描必须分页且有可信总量上限。超过上限时返回明确安全错误，不能静默把
+  不完整 Artifact 集合描述成完整结果；
+- FR-12：`run events` 校验 UUID4 Run ID、`after_sequence` 和 `limit`，结果按 sequence 升序，单页
+  不超过 EventStore 上限，并返回稳定 `next_after_sequence`/`has_more`；
+- FR-13：Run 不存在时返回稳定的 not-found 错误和非零退出码；数据库不存在时查询不得创建一个空
+  数据库冒充有效 Store；数据库 migration/corruption 错误只显示安全分类；
+- FR-14：人类 events 输出默认只显示有限一行摘要；`--json` 才输出完整 Event 对象。两种输出都来自
+  同一个 `EventPage`，不分别查询。
+
+### 6.3 配置、输出和兼容
+
+- FR-15：JSON result、inspection、Event page 和 safe command error 使用 Provider-neutral BearAgent
+  类型并有 schema/快照测试；时间、Enum、UUID 和嵌套 Event 按 Pydantic JSON mode 序列化；
+- FR-16：F-0005 不改变 v1/v2 Event 含义，不增加 SQLite migration。已有数据库可以直接 inspect；
+- FR-17：`doctor`、`--version` 和 `python -m bearagent` 保持兼容，help 明确展示 Run 命令层级；
+- FR-18：默认验证使用注入式 Fake Provider、临时 SQLite 和真实 workspace Tool 覆盖 CLI 全链，既不
+  访问网络也不读取开发者环境中的真实 key；
+- FR-19：F-0005 复用现有 OpenAI Responses adapter 的生产组装接口，但本 Feature 的测试、验收和收尾
+  不发起真实模型请求；测试必须能注入 Fake Provider 而不建立第二套 CLI/application 路径；
+- FR-20：F-0005 完成后，P1 仍保持 `进行中`，直到项目所有者单独决定真实模型 API/演练是否属于 P1，
+  并完成其余 P1 Reality Check；不得由本 Feature 提前改写该决定。
+
+## 7. 对外入口和模块连接
+
+```text
+Typer CLI
+  -> application Run command / query service
+     -> AgentLoop / EventStore port
+        -> bootstrap 组装 OpenAI + SQLite + workspace Tool + fixed Policy
+```
+
+| 模块 | F-0005 的变化 |
+|---|---|
+| `domain` | 增加 Provider-neutral query/output 模型，供 application、CLI 和未来接口复用 |
+| `application` | 增加执行 facade 与 Run inspect/Event page 查询；只依赖 domain、runtime 和 ports |
+| `bootstrap.py` | 唯一生产 composition root；可以导入具体 Provider、SQLite 和 workspace adapter |
+| `interfaces/cli` | 解析参数、读取有界 profile、选择 human/JSON renderer、映射退出码 |
+| `adapters` | 复用现有实现；只做暴露 production 组装所需的窄改动 |
+| `tests/evals` | 复用固定任务定义；增加显式凭据下的可选真实模型 runner |
+
+`domain`、`runtime` 和 `application` 不导入 Typer、OpenAI SDK、SQLite 或 workspace adapter。CLI 不保存
+第二份状态，bootstrap 不实现业务规则。
+
+## 8. 状态和保存的数据
+
+F-0005 继续使用 SQLite schema v1 和 Event payload v1/v2。执行命令创建的新 Run 由 F-0016 写 v2
+Event；projection 仍由同一 transaction 内的 Reducer 更新。profile 的非敏感 AgentConfig、预算和目标
+已经进入 `RunCreated`；profile 路径、workspace 绝对根、数据库路径、API key 和 base URL 不进入 Event。
+
+查询输出不是新事实，不写 Event。Artifact 由已有 Tool execution Event 重建；本 Feature 不创建 Artifact
+projection。回退后已有数据库和 `outputs/**` 保留。
+
+## 9. 失败时会发生什么
+
+- profile、workspace、Run ID 或分页参数无效：在 Provider/Tool 调用前拒绝；未创建 Run；
+- 零模型预算：先保存 RunCreated/RunStarted，再以 `budget_exhausted` 终止；不创建 SDK client、不读取凭据；
+- Provider 凭据缺失：首个模型 Activity 保存为 `provider_authentication` failure，Run 以同一安全 Error
+  终止；不打印 key、endpoint 或 SDK 原始异常；
+- 其他 client 配置无效：安全失败，不打印 endpoint 或 SDK 原始异常；
+- SQLite 初始化失败：不调用 Provider；若 Run 尚未创建，不伪造 Run ID 对应的事实；
+- Provider、Context 或预算失败：复用 AgentLoop 的安全 terminal Event 和 `RunResult`，退出码为 1；
+- Tool 请求失败：仍按 F-0016 记录并交回模型；CLI 不绕过 Loop 提前重试；
+- Ctrl+C/取消：`CancelledError` 原样传播，CLI 退出但不伪造 `RunFailed`；
+- 强制退出：已经提交的 Event 保留，非终态 projection 不显示成功，也不自动继续；
+- Tool 写入成功但 terminal Event append 失败：文件可能存在、Run 保持非终态；CLI 不猜测 Artifact 已被记录；
+- 查询遇到 corruption、future migration 或 Event/Artifact 解析失败：整个查询安全失败，不展示部分结果
+  为可信完整状态；
+- stdout broken pipe 或 renderer 失败：不改变已经提交的 Run/Event，也不重试外部动作。
+
+## 10. 安全与隐私
+
+- CLI 不提供 `--api-key`，避免凭据进入 shell history 或进程参数；Provider 从环境读取凭据；
+- profile 有 byte、UTF-8、JSON depth/node 和严格字段上限；它不能包含 adapter client 或授予权限；
+- workspace 文件动作全部经过 Registry、prepare、FixedToolPolicy 和 ToolExecutor；CLI/bootstrap 不直接读写
+  用户任务文件；
+- 模型服务是唯一生产网络边界；P1 仍没有任意 HTTP/浏览器/MCP Tool；
+- Run ID、database/profile/workspace 参数必须按各自边界校验。Error 不复制绝对根、SQL、原始异常、
+  authorization 或 Provider response；
+- `run events --json` 是用户显式请求的完整本地事实导出；默认 human 输出不打印 Event payload；
+- CLI 不声称提供多用户隔离、加密数据库或 P3 sandbox。
+
+## 11. 怎样检查执行过程
+
+执行完成后，`run inspect` 展示 Reducer projection；`run events` 展示按 sequence 排列的 immutable facts。
+用户可以把 Activity ID 与 ModelCallId/ToolCallId 对应起来，核对请求、开始、完成/失败、预算 usage、
+Policy 决定和 Artifact hash。
+
+CLI 自身只输出有限进度和安全诊断，不新增日志数据库。若 F-0005 完成后决定执行真实模型演练，必须
+另存结构化、无凭据的结果摘要，并注明模型可用性和网络影响；它不能替代确定性 CI。
+
+## 12. 上线与回退
+
+使用 Fake Provider 注入和临时数据库验证 CLI。F-0005 不读取真实凭据、不运行真实模型演练，也不关闭
+P1。没有服务端部署、feature flag 或 schema migration。
+
+回退时可移除 F-0005 的 CLI/application/bootstrap 新代码和未发布的 profile 示例，但必须保留已有 v1/v2
+Event 读取能力，不删除 `data/` 数据库或用户 `outputs/**`。若 CLI JSON 已发布后需要不兼容改变，使用新
+schema version，不能静默改写 version 1。
+
+## 13. 验收标准
+
+- AC-1：给定合法 profile、临时 workspace、SQLite 和 Fake Provider，`bearagent run` 应只通过 production
+  composition/application 路径完成任务，退出 0，并输出 Run ID、终态文本、Tool 状态和 hash 可核对 Artifact；
+- AC-2：给定 Provider/Context/预算导致的 terminal failure，`bearagent run` 应退出 1，stdout/JSON 只含
+  安全 Error；零预算不得创建 SDK client，缺少凭据应返回 `provider_authentication`，数据库中的 Event
+  与 RunState terminal 结论一致；
+- AC-3：给定同一数据库和 Run ID，`run inspect` 应返回与 `EventStore.get_run` 相同的 projection，并从
+  已提交 Tool Event 返回完整 Artifact 元数据；非终态 Run 不显示成功；
+- AC-4：给定多页 Event，`run events` 应按 sequence 返回有界页面、稳定游标和 `has_more`；非法 UUID、
+  cursor、limit、缺失 Run 或超量 inspect 均明确失败；
+- AC-5：当数据库不存在时，inspect/events 不创建空数据库；当数据库损坏或版本超前时，命令安全失败，
+  不打印 SQL、绝对路径或原始异常；
+- AC-6：当运行 `--json` 时，stdout 应只有一个 schema version 1 JSON 对象；human 与 JSON renderer 使用
+  同一 application 结果，UUID/时间/Enum/Event payload 可稳定 round-trip；
+- AC-7：当 profile 含未知/敏感字段、超大数据、非法 UTF-8 或越界配置时，命令应在任何 Provider/Tool
+  调用和数据库写入前拒绝；CLI 参数和输出不包含 API key；
+- AC-8：生产组装应只存在于 `bootstrap.py`，application/runtime/domain 不导入 adapter、SDK 或 Typer；
+  所有 workspace 动作仍经过固定 Policy 和 ToolExecutor；
+- AC-9：Ctrl+C 或强制中断后，已提交事实可由 inspect/events 查询，active Run 保持非终态；CLI 不自动
+  retry、resume 或伪造 `UNKNOWN`；
+- AC-10：`doctor`、`--version`、console script 和 `python -m bearagent` 回归通过；wheel 中包含 CLI、
+  composition 和查询代码；
+- AC-11：默认验证使用 Fake Provider 完成 5/5，不访问网络或真实凭据；production composition 的测试
+  注入 Fake Provider，并证明不会读取开发者环境中的真实 key；
+- AC-12：完整测试、Schema、Ruff、Pyright、文档链接、Starlight 和构建通过；Spec/Plan/Architecture、
+  Roadmap、README、学习页、开发者页和状态页据实关闭 F-0005，但保持 P1 `进行中`，并记录真实模型
+  API/演练和 P1 Reality Check 仍待后续决定。
+
+## 14. 验证方式
+
+- Unit：profile/参数边界、query service、Artifact 提取、pagination、renderer 和 exit code；
+- Contract：Run query/output JSON schema、Event page round-trip、现有 Store/Provider/Tool contracts；
+- Integration：Typer + Fake Provider + SQLite + 四个真实 workspace Tool；console script 和 module entrypoint；
+- Recovery：RunCreated/Activity/terminal append 边界、Ctrl+C、外部写后 append 失败和重开查询；
+- Security：profile secret 字段、Prompt 提权、Policy 旁路、路径/异常/SQL/SDK 脱敏、缺失/损坏数据库；
+- Eval/manual：Fake 5/5；本 Feature 不读取真实凭据或调用真实模型 API。
+
+## 15. 文档同步
+
+- [x] Engineering source of truth：Spec、Plan、ADR、Architecture、Roadmap、README、CLI help；
+- [x] Site beginner learning path：从运行命令到 inspect/events 的完整文件任务；
+- [x] Site developer documentation：composition root、application query、JSON contract 和失败边界；
+- [x] Site current status / milestone summary：关闭 F-0005，保持 P1 进行中，并写明真实模型/P1 Reality
+  Check 待后续决定；
+- [x] Architecture / ADR：生产组装和 CLI/application 依赖方向；
+- [x] Deployment docs：本地数据/profile/环境凭据，不新增公开服务；
+- [x] Generated reference：Run profile 与 CLI JSON schema/快照。
+
+## 16. 已确认的决定
+
+1. 使用 version 1 JSON Run profile 保存非敏感 `AgentConfig + BudgetLimits`；默认路径是
+   `data/p1-run-profile.json`，workspace 默认当前目录，数据库默认 `data/bearagent.db`；三者可显式覆盖，
+   API key/base URL 只从环境注入；
+2. 保持路线图语法：`bearagent run <objective>`，并在同一 `run` 命令组下提供 `inspect/events`；
+3. human events 默认只显示摘要；只有显式 `--json` 返回完整 Event payload；
+4. 默认验证保持离线 Fake 5/5；F-0005 不调用真实模型 API，不以真实模型 4/5 为完成门槛；Feature
+   完成后再单独决定真实模型 API/演练是否属于 P1，P1 在该决定与完整 Reality Check 前不关闭。
+
+项目所有者于 2026-08-20 接受本 Spec 和以上四项决定，并授权开始实现。

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -24,6 +24,7 @@ draft -> accepted -> implemented -> superseded
 - [F-0002：从 Event 计算 Run/Activity 状态和预算](F-0002-run-reducer-activity-lifecycle-budgets.md) — implemented
 - [F-0003：使用 SQLite 原子保存 Event 和 projection](F-0003-event-store-sqlite-projections.md) — implemented
 - [F-0004：建立模型内部接口和首个生产 adapter](F-0004-model-provider-first-adapter.md) — implemented
+- [F-0005：从命令行运行文件任务，并查看同一批已保存事实](F-0005-run-inspect-events-cli.md) — implemented
 - [F-0006：所有 Tool 请求经过同一个执行和权限入口](F-0006-tool-registry-executor-policy.md) — implemented
 - [F-0007：把 workspace 中的目录和文本安全地交给 Agent 阅读](F-0007-workspace-read-tools.md) — implemented
 - [F-0008：只把完整结果写进 outputs，并返回可核对的 Artifact](F-0008-atomic-output-artifacts.md) — implemented

--- a/scripts/generate_cli_schemas.py
+++ b/scripts/generate_cli_schemas.py
@@ -1,0 +1,20 @@
+"""Regenerate the committed CLI result schema compatibility snapshot."""
+
+import json
+from pathlib import Path
+
+from bearagent.interfaces.cli.contracts import public_cli_schemas
+
+SNAPSHOT_PATH = (
+    Path(__file__).resolve().parents[1] / "tests" / "contract" / "snapshots" / "cli_schemas.json"
+)
+
+
+def main() -> None:
+    """Write deterministic, reviewable JSON for all public CLI result models."""
+    content = json.dumps(public_cli_schemas(), indent=2, ensure_ascii=False) + "\n"
+    SNAPSHOT_PATH.write_text(content, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_wheel_cli.py
+++ b/scripts/smoke_wheel_cli.py
@@ -1,0 +1,132 @@
+"""Exercise an installed wheel's Run CLI without reading real Provider credentials."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+import bearagent.interfaces.cli.main as cli_main
+from bearagent.adapters.testing import ScriptedFakeModelProvider
+from bearagent.bootstrap import RunServices, build_run_services
+from bearagent.domain.agent import AgentConfig, ModelPricing, RunProfile
+from bearagent.domain.ids import IdGenerator
+from bearagent.domain.model import ModelCompleted, ModelFinishReason, ModelTextDelta, ModelUsage
+from bearagent.domain.runs import BudgetLimits
+from bearagent.ports.model import ModelProvider
+
+
+def main() -> None:
+    """Run, inspect, and page Events through the installed console application."""
+    provider = ScriptedFakeModelProvider(
+        [
+            (
+                ModelTextDelta(text="wheel smoke complete"),
+                ModelCompleted(
+                    provider_request_id="wheel-smoke-response",
+                    model="wheel-smoke-model",
+                    finish_reason=ModelFinishReason.STOP,
+                    usage=ModelUsage(input_tokens=2, output_tokens=3),
+                ),
+            )
+        ]
+    )
+    _inject_provider(provider)
+    runner = CliRunner()
+
+    with tempfile.TemporaryDirectory(prefix="bearagent-wheel-") as temporary:
+        root = Path(temporary)
+        profile_path = root / "profile.json"
+        database_path = root / "events.db"
+        profile = _profile()
+        profile_path.write_text(
+            json.dumps(profile.model_dump(mode="json")),
+            encoding="utf-8",
+        )
+        run = runner.invoke(
+            cli_main.app,
+            [
+                "run",
+                "wheel smoke task",
+                "--profile",
+                str(profile_path),
+                "--workspace",
+                str(root),
+                "--database",
+                str(database_path),
+                "--json",
+            ],
+        )
+        if run.exit_code != 0:
+            raise RuntimeError("installed wheel Run command failed")
+        run_payload = json.loads(run.stdout)
+        run_id = run_payload["result"]["run_id"]
+
+        for command in ("inspect", "events"):
+            result = runner.invoke(
+                cli_main.app,
+                ["run", command, run_id, "--database", str(database_path), "--json"],
+            )
+            if result.exit_code != 0:
+                raise RuntimeError(f"installed wheel {command} command failed")
+            payload = json.loads(result.stdout)
+            if payload["command"] != command:
+                raise RuntimeError(f"installed wheel {command} output is invalid")
+
+    print("Installed wheel Run/inspect/events smoke test passed.")
+
+
+def _inject_provider(provider: ModelProvider) -> None:
+    async def build_with_fake(
+        *,
+        profile_path: str | os.PathLike[str],
+        workspace_path: str | os.PathLike[str],
+        database_path: str | os.PathLike[str],
+        model_provider: ModelProvider | None = None,
+        id_generator: IdGenerator | None = None,
+    ) -> RunServices:
+        del model_provider
+        return await build_run_services(
+            profile_path=profile_path,
+            workspace_path=workspace_path,
+            database_path=database_path,
+            model_provider=provider,
+            id_generator=id_generator,
+        )
+
+    cli_main.build_run_services = build_with_fake
+
+
+def _profile() -> RunProfile:
+    return RunProfile(
+        agent_config=AgentConfig(
+            agent_id="wheel-smoke-agent",
+            agent_version="v1",
+            instructions="Return a short offline smoke-test response.",
+            model="wheel-smoke-model",
+            prompt_version="v1",
+            context_version="v1",
+            max_output_tokens=128,
+            model_timeout_ms=5_000,
+            max_context_chars=16_384,
+            max_tool_result_bytes=4_096,
+            tool_names=(),
+            pricing=ModelPricing(
+                version="offline-v1",
+                input_microusd_per_million_tokens=0,
+                output_microusd_per_million_tokens=0,
+            ),
+        ),
+        budget_limits=BudgetLimits(
+            max_model_iterations=1,
+            max_tokens=128,
+            max_cost_microusd=1,
+            max_wall_time_ms=10_000,
+            max_tool_calls=0,
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -44,6 +44,7 @@ export default defineConfig({
             { label: 'Tool 请求为什么要过四道检查', slug: 'learn/tool-execution-boundary' },
             { label: 'Windows 和 Unix 路径怎样统一', slug: 'learn/workspace-read-boundary' },
             { label: '一次文件任务怎样走完整条链', slug: 'learn/agent-loop-file-task' },
+            { label: '从命令行运行并检查 Run', slug: 'learn/run-inspect-events' },
           ],
         },
         {
@@ -66,6 +67,7 @@ export default defineConfig({
             { label: 'F-0007：workspace 只读 Tool', slug: 'development/workspace-read-tools' },
             { label: 'F-0008：原子输出与 Artifact', slug: 'development/atomic-output-artifacts' },
             { label: 'F-0016：有界 Agent Loop', slug: 'development/agent-loop' },
+            { label: 'F-0005：生产 CLI 与查询', slug: 'development/run-cli' },
           ],
         },
         {

--- a/site/src/content/docs/zh-cn/architecture/index.md
+++ b/site/src/content/docs/zh-cn/architecture/index.md
@@ -19,10 +19,10 @@ sourceRefs:
 再把内容交给下一次模型调用。这条路径跨过多个模块，但每个模块只负责其中一段。
 
 :::caution[图中同时包含当前连接和后续能力]
-当前已实现领域类型、Run/Activity 状态、Reducer、预算检查、SQLite EventStore、首个 OpenAI
-Responses adapter、Registry、固定 Policy、统一 ToolExecutor、三个 workspace 只读 Tool，以及只写
-`outputs/**` 并返回 Artifact 的原子写入 Tool。F-0016 已实现 ContextBuilder 和 application Agent Loop。
-生产 CLI 属于 F-0005；用户审批和隔离环境属于 P3。
+当前已实现领域类型、Run/Activity 状态、Reducer、预算检查、SQLite EventStore、OpenAI Responses
+adapter、Registry、固定 Policy、workspace 读写、Artifact、ContextBuilder 和 application Agent Loop。
+F-0005 已接通 production composition 与 `run/inspect/events`；真实模型退出演练尚未完成，用户审批和
+隔离环境属于 P3。
 :::
 
 ```mermaid

--- a/site/src/content/docs/zh-cn/development/agent-loop.md
+++ b/site/src/content/docs/zh-cn/development/agent-loop.md
@@ -79,5 +79,5 @@ Event 历史，不给 Run/Activity projection 添加 v2 专属字段，所以 v1
 - `tests/evals/test_p1_agent_loop_tasks.py`：五个任务分别跑内存与 SQLite Store；
 - `tests/integration/test_tool_executor.py`：记录式入口与旧入口共享执行行为。
 
-当前没有 CLI 组装、重启恢复、Approval 或 sandbox。修改 Loop 时，先证明没有旁路已有 port，再更新
-Feature Spec、架构、学习页、开发者页和当前状态。
+F-0005 已用 production composition 和 CLI 调用这条 Loop；重启恢复、Approval 与 sandbox 仍未实现。
+修改 Loop 时，先证明没有旁路已有 port，再更新 Feature Spec、架构、学习页、开发者页和当前状态。

--- a/site/src/content/docs/zh-cn/development/atomic-output-artifacts.md
+++ b/site/src/content/docs/zh-cn/development/atomic-output-artifacts.md
@@ -90,5 +90,5 @@ F-0016 已由 Agent Loop 把 ToolCallId、来源 Activity、规范化请求和�
 5. `workspace.write` 保持 `WORKSPACE_WRITE/NOT_SAFE`，Executor 不自动重试；
 6. F-0008 不增加 Event、SQLite 状态、delete Tool 或自动清理。
 
-当前 application RunResult 已能返回 Artifact 元数据，但还不能从 CLI 接收用户任务或查询 Artifact；
-这些用户入口属于 F-0005。
+application RunResult 会返回 Artifact 元数据；F-0005 的 CLI 已能启动任务，并由 `run inspect` 从已提交
+Tool Event 重建同一组 Artifact。当前仍没有独立 Artifact 数据库或下载 API。

--- a/site/src/content/docs/zh-cn/development/index.md
+++ b/site/src/content/docs/zh-cn/development/index.md
@@ -7,6 +7,7 @@ sourceRefs:
   - architecture/overview
   - ai-development-sop
   - F-0016
+  - F-0005
 ---
 
 开发者文档不复制 Spec，也不把每个目录重新列一遍。它负责回答三个问题：代码从哪里进入、关键
@@ -30,6 +31,7 @@ sourceRefs:
 - [F-0007：workspace 只读 Tool](workspace-read-tools.md)——跨平台路径边界、list/read/search 和安全测试；
 - [F-0008：原子输出与 Artifact](atomic-output-artifacts.md)——同目录暂存、原子提交、结果元数据和故障窗口；
 - [F-0016：有界 Agent Loop](agent-loop.md)——Context、v2 Event、串行模型/Tool 调度、故障窗口和固定任务；
+- [F-0005：生产 CLI 与查询](run-cli.md)——Run profile、composition root、inspect/events、JSON 契约和失败边界；
 - [Feature 完成时怎样更新文档](feature-documentation.md)——哪些事实写在 `docs/`，哪些解释写在站点；
 - [本地运行文档站](../guides/local-docs.md)——安装、构建和检查 Starlight。
 

--- a/site/src/content/docs/zh-cn/development/run-cli.md
+++ b/site/src/content/docs/zh-cn/development/run-cli.md
@@ -1,0 +1,92 @@
+---
+title: F-0005 生产 CLI 和查询服务实现导读
+description: 找到 Run profile、composition root、EventStore query、CLI JSON 契约和边界测试。
+bearStatus: implemented
+sourceRefs:
+  - F-0005
+  - PLAN-F-0005
+  - ADR-0014
+---
+
+修改 `bearagent run` 时，先沿着 `interfaces -> bootstrap/application -> ports -> adapters` 阅读。CLI 只
+负责解析和渲染；业务事实仍来自 AgentLoop、Reducer 和 EventStore。
+
+## 代码地图
+
+| 位置 | 责任 |
+|---|---|
+| `domain/agent.py` | 严格、非敏感的 RunProfile version 1 |
+| `domain/queries.py` | RunInspection 与有界 EventPage |
+| `application/run_queries.py` | 只通过 EventStore 查询 projection、Event 和 Artifact |
+| `bootstrap.py` | 读取 profile，组装 OpenAI、SQLite、Tools、Policy、Executor 和 AgentLoop |
+| `interfaces/cli/contracts.py` | version 1 Run/inspect/events result 与 safe error envelope |
+| `interfaces/cli/renderers.py` | human 摘要和单对象 JSON 序列化 |
+| `interfaces/cli/main.py` | Typer 参数、退出码和异步 application 调用 |
+
+## composition root 只做组装
+
+`build_run_services` 先校验 profile 和 workspace，再选择 profile 明确列出的 Tool。未配置的 Tool 不会
+进入 Registry，因此既不会出现在 ModelRequest 中，也不会被 Policy 允许。随后它初始化同一个
+SQLite Store，并把 Store 同时交给 AgentLoop 和 RunQueryService。
+
+测试可以注入 Provider-neutral Fake Provider；真实 CLI 不暴露 `--api-key`，而是构造已有
+OpenAIResponsesProvider。adapter 对象进入 AgentLoop，但 SDK client 只在首个真实模型 Activity 开始时
+创建，并从受信任进程环境读取凭据。零预算 Run 因此可以在不读取凭据的情况下持久失败；非零预算但
+缺少凭据时，Activity/Run 保存安全的 `provider_authentication`。domain、runtime 和 application 不导入
+OpenAI、SQLite adapter 或 Typer；architecture test 持续检查这个方向。
+
+Profile loader 使用文件描述符读取最多 128 KiB，并比较打开前后快照。链接、reparse point、替换竞态、
+非法 UTF-8、未知字段和敏感字段都会变成有限的 safe Error。`inspect/events` 在初始化前要求数据库已
+存在且是普通文件，避免一次拼错路径悄悄创建空库。
+
+## query service 为什么不写 SQL
+
+`RunQueryService.inspect` 先取得 RunState，再以最多 1,000 条一页扫描 Event，总量最多 10,000 条。
+每页必须属于同一个 Run，sequence 连续并且不超过 projection 的 `last_sequence`。v2
+ToolCallCompleted payload 经过正式 parser 后，才允许提取 `workspace.write` Artifact。
+
+`events` 同样先读取 projection，之后只查询当时已提交的有限前缀。返回的 EventPage 验证 Run ID、
+顺序、游标、页大小和 `has_more`。查询层没有 SQL、SQLite row 或第二个 Reducer。
+
+## `run OBJECTIVE` 为什么还能有子命令
+
+Typer 通常要求 command group 后先写子命令，但路线图已经固定 `bearagent run OBJECTIVE`。F-0005 的
+`DefaultRunGroup` 只做一条解析规则：第一个 token 不是 `inspect/events` 时，路由到隐藏的 execute
+handler。`run --help` 保留组帮助；目标若恰好叫 `inspect`、`events` 或以短横线开头，可使用
+`bearagent run -- OBJECTIVE`。integration test 同时覆盖无子命令执行和两个查询子命令，防止语法回归。
+
+## 输出和失败边界
+
+human 与 JSON renderer 读取同一个 Pydantic result。Run 成功退出 0；Run 以 failed 终止或安全边界
+失败退出 1；Typer 用法错误退出 2。JSON stdout 只有一个 versioned object，预分配 Run ID 只写 stderr。
+默认 Event 摘要不打印 payload；完整 payload 只在显式 `events --json` 中出现。
+
+不要把 `except Exception` 的原始文本直接交给用户。已规范化的 BearAgentError 可以保留 ErrorInfo；
+未知异常只能变成 `internal_error`。取消不在这一层改写为 terminal Event。
+
+## Fake Provider 怎样验证真实接线
+
+`tests/evals/test_p1_agent_loop_tasks.py` 定义五个版本化文件任务。每个任务的 Fake Provider 是逐请求
+脚本：第 1 次模型请求返回哪一个 Tool call、第 2 次返回什么结果都事先固定；它不会读取 Prompt 后临时
+编造答案。测试断言请求次数、Tool 名称和参数、Event sequence、终止原因、输出内容与 Artifact hash。
+
+production composition 测试只通过 `build_run_services(model_provider=fake)` 替换 ModelProvider。SQLite、
+WorkspaceBoundary、四个真实 Tool、Registry、FixedToolPolicy、ToolExecutor、AgentLoop 和 query service
+仍使用生产实现。任务完成后重新打开 SQLite，再通过 `inspect/events` 检查已提交事实。
+
+`tests/integration/test_run_cli.py` 在 Typer 边界 monkeypatch 同一个 composition seam，然后真实调用
+`run/inspect/events`。除此之外，它还不注入 Provider 地验证两种生产失败：零预算不会创建 SDK client；
+缺少凭据会得到持久的 `provider_authentication`。`tests/security/test_model_provider.py` 则把敏感文本放进
+client 初始化异常，确认公开 Error 不复制原始内容。
+
+## 从哪里看证据
+
+- `tests/unit/test_run_queries.py`：分页、游标、缺失 Run、总量上限和不完整历史；
+- `tests/unit/test_bootstrap.py`：profile 字节/链接边界、Tool allowlist、预分配 Run ID 和缺失数据库；
+- `tests/integration/test_run_cli.py`：Fake Provider + production composition + SQLite 的 CLI 全链；
+- `tests/security/test_cli_boundaries.py`：profile secret、损坏 Event 和未来 migration 脱敏；
+- `tests/recovery/test_agent_loop_boundaries.py`：取消与写后 append 失败的查询结果；
+- `tests/evals/test_p1_agent_loop_tasks.py`：五个固定任务通过 production composition 并重开查询；
+- `tests/contract/test_cli_schemas.py`：machine-readable 输出 Schema 快照。
+
+F-0005 没有增加 SQLite migration、网络 Tool、恢复或 Approval，也没有用真实模型完成 P1 退出演练。

--- a/site/src/content/docs/zh-cn/index.mdx
+++ b/site/src/content/docs/zh-cn/index.mdx
@@ -23,6 +23,7 @@ sourceRefs:
   - F-0008
   - F-0016
   - F-0015
+  - F-0005
 ---
 
 import { CardGrid, LinkCard } from '@astrojs/starlight/components';
@@ -54,11 +55,10 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
   />
 </CardGrid>
 
-:::caution[执行链已实现，但生产 CLI 还没有组装]
-当前 application Agent Loop 已从持久 Event 构造 Context，串行调用 ModelProvider 和 ToolExecutor，
-并把完整 v2 Activity 事实写回内存或 SQLite Store。五个 Fake Provider 文件任务已通过。F-0005 尚未
-把真实 Provider、workspace、SQLite 和 `run/inspect/events` CLI 组装起来，所以还不能从命令行运行
-真实 Agent 任务。路线图中的更晚能力也不是当前功能。
+:::note[生产 CLI 已接通，P1 仍未关闭]
+`run/inspect/events` 已把 Provider、workspace、SQLite、Policy 和 Agent Loop 组装到同一条本地路径。
+五个固定任务通过 production composition 的离线 Fake Provider 验证；真实模型 4/5 gate 与完整 P1
+Reality Check 尚待下一步决定。路线图中的恢复、Approval 和 sandbox 仍不是当前功能。
 :::
 
 ## BearAgent 想把三件事做可靠

--- a/site/src/content/docs/zh-cn/learn/agent-loop-file-task.md
+++ b/site/src/content/docs/zh-cn/learn/agent-loop-file-task.md
@@ -62,10 +62,11 @@ Tool 次数、token、费用和总时间。
 ## 当前实现与后续能力
 
 F-0016 已提供 Python application 接口，并用五个固定 Fake Provider 任务在内存和 SQLite Store 上验证
-读取、搜索、写入、替换、路径拒绝和预算终止。它还没有生产 CLI；F-0005 才会组装真实 Provider、
-SQLite、workspace Tool 和 `run/inspect/events` 命令。
+读取、搜索、写入、替换、路径拒绝和预算终止。F-0005 已组装 Provider、SQLite、workspace Tools 与
+`run/inspect/events`，并让同一任务集通过 production composition；自动验证仍没有调用真实模型 API。
 
 进程重启后自动继续、Attempt、`UNKNOWN` 和写后 reconcile 属于 P2。用户 Approval、Grant 和 sandbox
 属于 P3。当前的持久边界让失败可检查，但不宣称 exactly-once。
 
-继续阅读[有界 Agent Loop 实现导读](../development/agent-loop.md)，查看代码位置和测试证据。
+继续阅读[从命令行运行并检查一次 Run](run-inspect-events.md)，再到
+[有界 Agent Loop 实现导读](../development/agent-loop.md)查看代码位置和测试证据。

--- a/site/src/content/docs/zh-cn/learn/atomic-output-boundary.md
+++ b/site/src/content/docs/zh-cn/learn/atomic-output-boundary.md
@@ -74,6 +74,6 @@ F-0008 所说的原子可见性。
 路径越界、目标不是普通文件或内容超限时，都不会提交目标。
 
 这条写入边界已有创建、替换、路径逃逸、链接、目标变化、`fsync`/replace 失败、timeout 和取消测试。
-F-0016 已实现 Agent Loop 和 Tool Event 接线；Run CLI 仍属于 F-0005。
+F-0016 已实现 Agent Loop 和 Tool Event 接线；F-0005 已让 Run CLI 返回并查询已提交的 Artifact 元数据。
 
 继续阅读[原子输出与 Artifact 实现导读](../development/atomic-output-artifacts.md)，查看代码位置和测试。

--- a/site/src/content/docs/zh-cn/learn/index.md
+++ b/site/src/content/docs/zh-cn/learn/index.md
@@ -12,6 +12,7 @@ sourceRefs:
   - F-0007
   - F-0008
   - F-0016
+  - F-0005
 ---
 
 这条学习路径始终使用同一个例子：用户要求 Agent 阅读仓库文档，并把总结写进 `outputs/`。
@@ -84,5 +85,10 @@ exactly-once。
 [一次文件任务怎样走完整条执行链](agent-loop-file-task.md)把前面的边界接起来。你会看到 Context
 怎样只从已提交 Event 重建、外部调用为什么发生在 started Event 之后，以及 Tool 失败怎样回到模型。
 
-当前这条路径覆盖已实现的 F-0001 至 F-0004、F-0006 至 F-0008 和 F-0016。生产 Run CLI 仍属于
-F-0005；崩溃恢复和用户授权分别属于 P2、P3。
+## 11. 从终端启动后检查同一批事实
+
+[从命令行运行并检查一次 Run](run-inspect-events.md)说明 Run profile、production composition、
+`inspect/events` 和 human/JSON 输出怎样接到现有 EventStore，而不复制 SQL 或状态规则。
+
+当前这条路径覆盖已实现的 F-0001 至 F-0008、F-0015 和 F-0016。真实模型 P1 退出演练仍待单独
+决定；崩溃恢复和用户授权分别属于 P2、P3。

--- a/site/src/content/docs/zh-cn/learn/run-inspect-events.md
+++ b/site/src/content/docs/zh-cn/learn/run-inspect-events.md
@@ -1,0 +1,76 @@
+---
+title: 从命令行运行并检查一次 Run
+description: 用同一个 SQLite 数据库启动文件任务、查看状态，再分页读取已经提交的 Event。
+bearStatus: implemented
+sourceRefs:
+  - F-0005
+  - ADR-0014
+  - F-0016
+---
+
+你运行一个文件任务后，最先要回答的不是“模型说了什么”，而是三个更具体的问题：这次 Run 的 ID
+是什么、最终状态是什么、哪些事实真的保存下来了。F-0005 用三个命令回答它们：
+
+```powershell
+bearagent run "阅读 docs 并把总结写到 outputs/summary.md"
+bearagent run inspect <run-id>
+bearagent run events <run-id> --after-sequence 0 --limit 100
+```
+
+## 一次命令怎样接到已有边界
+
+```mermaid
+flowchart TB
+    C["CLI 校验 objective 和路径"] --> B["bootstrap 读取 Run profile"]
+    B --> G["组装 Provider、SQLite、Policy 和 workspace Tools"]
+    G --> L["AgentLoop 保存并执行 Run"]
+    L --> R["RunResult"]
+    R --> H["human 或 JSON 输出"]
+    D["inspect / events"] --> Q["application query service"]
+    Q --> S["EventStore port"]
+```
+
+CLI 不计算状态，也不读取 SQLite 表。`run` 把经过校验的 `RunInput` 交给 AgentLoop；`inspect` 和
+`events` 把 Run ID 交给 application query service。query service 再通过 EventStore port 读取同一份
+projection 和 Event，所以不存在“终端显示成功、数据库却是另一种状态”的第二套规则。
+
+## Run profile 为什么不放密钥
+
+默认 profile 是 `data/p1-run-profile.json`。它的 version 1 只有两个主体字段：`agent_config` 和
+`budget_limits`。model、Prompt、Context、Tool 名称、价格版本和预算会随 RunCreated Event 保存，便于
+以后解释这次执行；API key、base URL、workspace 绝对路径和数据库路径不会进入 profile 或 Event。
+
+profile 必须是有限大小的普通 UTF-8 JSON 文件。未知字段、链接、非法编码和越界值都会在数据库写入
+和 Provider 调用前失败。Provider 凭据只能从进程环境注入。
+
+profile 不是“每个 Tool 一份 JSON”，也不需要为每个问题重新生成。每个 Tool 的参数 schema 已由
+`ToolSpec` 定义；profile 只选择这个 Agent 能看到哪些 Tool。同一份 profile 可以先后运行“总结 docs”
+和“比较两份说明”，每次变化的是 objective。只有模型、Agent 指令、预算或 Tool 权限发生变化时，才
+需要换 profile。
+
+仓库提供的示例 profile 把预算设为 0。使用它启动 Run 时，AgentLoop 会保存 RunCreated、RunStarted 和
+`budget_exhausted` RunFailed；OpenAI SDK client 不会创建，模型和 Tool 都不会调用。预算非零但环境中
+没有 Provider 凭据时，首个模型 Activity 和 Run 会以安全的 `provider_authentication` 失败。这两种
+情况都能用 `inspect/events` 查看，不再只得到无法定位的 composition 错误。
+
+## inspect 与 events 看的是不同层次
+
+`inspect` 返回 Reducer 已计算出的完整 RunState，包括预算、usage、Activity、terminal Error 和最后
+sequence。它还会分页扫描已提交的 v2 Tool completed Event，从 `workspace.write` 结果重建 Artifact
+元数据。如果 Event 总量超过可信上限，命令会明确失败，不会把不完整 Artifact 列表说成完整结果。
+
+`events` 返回一页不可变事实，并带回 `next_after_sequence` 和 `has_more`。默认 human 输出每条只显示
+sequence、时间、类型和 schema version，不显示 payload。`--json` 是显式完整导出，可能包含用户目标、
+模型文本和 ToolResult，不应当作普通日志公开。
+
+## 中断后会看到什么
+
+如果调用被取消，已经提交的 Event 仍在数据库里。`inspect` 会如实显示 `running` 以及最后一个
+PENDING/RUNNING Activity；它不会猜测成功，也不会自动追加 RunFailed。若文件已经写成，但
+ToolCallCompleted 没有提交，查询也不会从文件系统反推一个 Artifact。
+
+自动恢复、retry、Attempt、Receipt 和 `UNKNOWN` 属于 P2。F-0005 的自动验收使用注入式 Fake Provider，
+没有读取真实 key 或调用真实模型。是否把真实模型 API/4-of-5 演练保留为 P1 关闭门，会在 F-0005
+完成后单独决定。
+
+继续阅读[生产 CLI 和查询服务实现导读](../development/run-cli.md)，查看代码位置、Schema 和故障测试。

--- a/site/src/content/docs/zh-cn/learn/tool-execution-boundary.md
+++ b/site/src/content/docs/zh-cn/learn/tool-execution-boundary.md
@@ -69,7 +69,7 @@ Policy 看到的是 `prepare` 整理后的参数。因此不会出现“权限�
 
 F-0006 建好了统一入口，F-0007 已让三个只读 Tool 真正打开受限 workspace，F-0008 也让
 `workspace.write` 通过同一入口原子写入 `outputs/**`。F-0016 的 Agent Loop 已调用 Executor 并把请求、
-Policy 决定和结果写成 Event；F-0005 才会用 CLI 展示 Tool Activity。
+Policy 决定和结果写成 Event；F-0005 的 `run` 与 `inspect` 已用同一 RunState 展示 Tool Activity。
 
 想看路径怎样检查，可以继续阅读
 [Windows 和 Unix 路径为什么先变成同一种写法](workspace-read-boundary.md)。

--- a/site/src/content/docs/zh-cn/project/milestones.md
+++ b/site/src/content/docs/zh-cn/project/milestones.md
@@ -31,10 +31,9 @@ P1 要接通 SQLite、一个真实模型、受限文件工具、有结束条件�
 模型在固定配置下至少完成 4 个，并且非法路径和预算耗尽都有清楚的失败记录。
 
 当前已经完成 SQLite EventStore、首个 OpenAI Responses adapter、Registry、固定 Policy、统一
-ToolExecutor、workspace 目录列出、UTF-8 读取、普通字符串搜索，以及 `outputs/**` 原子写入和
-Artifact 元数据。F-0016 已用 ContextBuilder 和串行 Agent Loop 把它们接成一次 Run，并让五个
-Fake Provider 任务在内存与 SQLite Store 上通过。P1 还需要 F-0005 的 Run CLI、查询输出和真实模型
-4/5 退出演练，才能形成阶段要求的用户结果。
+ToolExecutor、workspace 读写、原子 Artifact、ContextBuilder 和串行 Agent Loop。F-0005 已接通
+`run/inspect/events`、production composition 与查询，并让五个 Fake Provider 任务再次通过真实
+SQLite/workspace 组合。P1 仍要决定并执行真实模型 4/5 gate（若保留），再完成里程碑 Reality Check。
 
 P1 只保证已经保存的事实可以查看。进程退出后不会自动继续。
 

--- a/site/src/content/docs/zh-cn/project/positioning.md
+++ b/site/src/content/docs/zh-cn/project/positioning.md
@@ -12,8 +12,9 @@ BearAgent 想让个人 Agent 在本地可靠地完成长任务：用户能看清
 
 :::caution[这是产品方向，不是当前功能清单]
 当前已完成工程基础、内部数据类型、状态与预算规则、SQLite EventStore、首个模型 adapter、统一
-ToolExecutor、workspace 读写 Tool、原子输出 Artifact、有界 Agent Loop 和本地文档站。五个离线
-Fake Provider 文件任务已通过；生产 CLI 尚未组装，因此用户还不能启动真实模型任务。
+ToolExecutor、workspace 读写 Tool、原子输出 Artifact、有界 Agent Loop、本地文档站和
+`run/inspect/events` production composition。五个离线 Fake Provider 文件任务已通过；真实模型 P1
+退出演练尚未完成。
 :::
 
 ## 第一个用户和第一个任务

--- a/site/src/content/docs/zh-cn/project/status.md
+++ b/site/src/content/docs/zh-cn/project/status.md
@@ -13,10 +13,12 @@ sourceRefs:
   - F-0008
   - F-0016
   - F-0015
+  - F-0005
 ---
 
-BearAgent 已有可由 Python 调用的有界 Agent Loop，但还不能从 CLI 启动真实模型文件任务。已经写入
-路线图、架构或 ADR 的更晚设计，不等于已经接通运行入口。
+BearAgent 已有本地 `run/inspect/events` CLI。它把严格 Run profile、OpenAI Responses adapter、SQLite、
+固定 Policy、workspace Tools 和有界 Agent Loop 组装到同一入口。自动验收使用 Fake Provider；没有
+真实模型 4/5 证据，因此 P1 仍未关闭。
 
 ## 已经可以验证
 
@@ -31,22 +33,22 @@ BearAgent 已有可由 Python 调用的有界 Agent Loop，但还不能从 CLI �
 | F-0007 workspace 只读 Tool | 一层目录列出、分段 UTF-8 读取、普通字符串搜索和跨平台路径边界 |
 | F-0008 原子输出与 Artifact | 只向 `outputs/**` 写有限 UTF-8 文本；创建/替换以一次 replace 提交并返回 hash 元数据 |
 | F-0016 有界 Agent Loop | 从已提交 Event 构造 Context，串行调用模型与 Tool，保存 v2 事实；五个 Fake 任务在两种 Store 上通过 |
+| F-0005 生产 CLI 与查询 | `run/inspect/events`、严格 profile、production composition、分页查询和 human/JSON；零预算/缺凭据保留安全 terminal Run；五个任务通过真实 SQLite/Tools + Fake Provider |
 | F-0015 本地文档站 | 中文 Starlight 页面、搜索和 Mermaid 可以在本地构建 |
 
-## P1 还需要接通
+## P1 还需要决定和检查
 
-- `run`、`inspect`、`events` 命令和 production adapter 组装；
-- 使用相同任务定义完成真实模型 4/5 退出演练。
+- 决定真实模型 API/4-of-5 演练是否继续作为 P1 关闭门；
+- 若保留该门，使用同一任务定义、固定配置和预算完成演练；
+- 对整个 P1 做一次 Reality Check，核对代码、测试、安装包、文档和失败边界。
 
-F-0016 已实现。F-0005 在 Roadmap 中有稳定 Feature ID，但开始前仍需按仓库流程确认 Spec、ADR 和
-Plan；没有 Spec 的条目不能授权实现。
+F-0005 的完成只关闭 Feature，不自动关闭里程碑，也不把离线 Fake 5/5 描述成真实模型结果。
 
 ## 当前明确不能做
 
-- 不能从 CLI 启动一次真实模型文件任务，也没有 `inspect/events` 人类输出；
+- CLI 已具备真实 Provider 的装配路径，但当前没有真实 API 演练证据；
 - SQLite 可以保存 Event 和 projection，但进程重启后不会自动继续 Run；
-- application Loop 可以调度 ModelProvider port，但生产 OpenAI adapter 尚未与 CLI、SQLite 和 workspace
-  配置组装；
+- `inspect/events` 只能查看已提交事实，不能 resume、retry 或修复非终态 Run；
 - Tool 请求和 Artifact 已随 v2 Event 写入 Store，但还没有用户 Approval、sandbox、服务器 API 或
   独立 Artifact 查询表；
 - 文档站只在本地和 CI 构建，尚未发布到 `docs.bearguin.cn`。

--- a/src/bearagent/adapters/model/openai_responses.py
+++ b/src/bearagent/adapters/model/openai_responses.py
@@ -13,6 +13,7 @@ from openai import (
     AsyncOpenAI,
     AuthenticationError,
     BadRequestError,
+    OpenAIError,
     PermissionDeniedError,
     RateLimitError,
 )
@@ -82,18 +83,20 @@ class OpenAIResponsesProvider:
             raise ValueError("Pass either a client or client configuration, not both")
         if client is not None and client.max_retries != 0:
             raise ValueError("Injected OpenAI client must disable automatic retries")
-        self._client = client or AsyncOpenAI(
-            api_key=api_key,
-            base_url=base_url,
-            max_retries=0,
-        )
+        # Production credentials come from the process environment. Delay SDK
+        # client creation until a model Activity actually starts so a zero-budget
+        # Run can fail durably without requiring credentials it will never use.
+        self._client = client
+        self._api_key = api_key
+        self._base_url = base_url
 
     async def stream(self, request: ModelRequest) -> AsyncIterator[ModelEvent]:
         terminal_seen = False
         output_chars = 0
         provider_tool_calls: dict[str, tuple[str, str]] = {}
         try:
-            stream = await self._client.responses.create(
+            client = self._client_or_create()
+            stream = await client.responses.create(
                 model=request.model,
                 input=_translate_input(request),
                 tools=_translate_tools(request),
@@ -136,6 +139,25 @@ class OpenAIResponsesProvider:
             raise _classify_sdk_error(cause) from cause
         if not terminal_seen:
             raise _protocol_error("Provider stream ended without a completion event.")
+
+    def _client_or_create(self) -> AsyncOpenAI:
+        if self._client is not None:
+            return self._client
+        try:
+            client = AsyncOpenAI(
+                api_key=self._api_key,
+                base_url=self._base_url,
+                max_retries=0,
+            )
+        except OpenAIError as cause:
+            raise _provider_error(
+                ErrorCode.PROVIDER_AUTHENTICATION,
+                "Model Provider credentials are not configured.",
+                retryable=False,
+                cause=cause,
+            ) from cause
+        self._client = client
+        return client
 
 
 def _translate_input(request: ModelRequest) -> list[ResponseInputItemParam]:

--- a/src/bearagent/application/__init__.py
+++ b/src/bearagent/application/__init__.py
@@ -1,5 +1,6 @@
 """Application commands and use cases composed around runtime ports."""
 
 from bearagent.application.agent_loop import AgentLoop, Clock, SystemClock
+from bearagent.application.run_queries import RunQueryError, RunQueryService
 
-__all__ = ["AgentLoop", "Clock", "SystemClock"]
+__all__ = ["AgentLoop", "Clock", "RunQueryError", "RunQueryService", "SystemClock"]

--- a/src/bearagent/application/agent_loop.py
+++ b/src/bearagent/application/agent_loop.py
@@ -1,14 +1,13 @@
 """Serial P1 Agent Loop coordinated across persisted Activity boundaries."""
 
 import asyncio
-from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Protocol
 
 from pydantic import BaseModel, ValidationError
 
 from bearagent.domain.agent import RunInput, RunResult
-from bearagent.domain.artifacts import Artifact
+from bearagent.domain.artifacts import Artifact, artifact_from_tool_result_data
 from bearagent.domain.errors import ErrorCategory, ErrorCode, ErrorInfo
 from bearagent.domain.events import Event
 from bearagent.domain.ids import (
@@ -86,12 +85,14 @@ class AgentLoop:
         self._clock = SystemClock() if clock is None else clock
         self._id_generator = Uuid4IdGenerator() if id_generator is None else id_generator
 
-    async def run(self, run_input: RunInput) -> RunResult:
+    async def run(self, run_input: RunInput, *, run_id: RunId | None = None) -> RunResult:
         """Create and drive one Run until it reaches a persisted terminal state."""
         available_tool_names = {spec.name for spec in self._tool_specs}
         if any(name not in available_tool_names for name in run_input.agent_config.tool_names):
             raise ValueError("AgentConfig references a Tool that is not registered")
-        run_id = self._id_generator.new(RunId)
+        # A composition root may allocate the ID for early CLI visibility. The
+        # identifier carries no authority; all execution still starts at append.
+        run_id = self._id_generator.new(RunId) if run_id is None else run_id
         correlation_id = self._id_generator.new(CorrelationId)
         state = await self._append(
             None,
@@ -402,7 +403,7 @@ class AgentLoop:
                     )
                 state = await self._event_store.append(terminal_event)
                 try:
-                    artifact = _artifact_from_execution(
+                    artifact = artifact_from_tool_result_data(
                         execution.request.name, execution.result.data
                     )
                 except ValidationError:
@@ -594,12 +595,3 @@ def _compact_execution_failure(
         ),
         persistence_truncated=True,
     )
-
-
-def _artifact_from_execution(
-    tool_name: str,
-    data: Mapping[str, object],
-) -> Artifact | None:
-    if tool_name != "workspace.write" or "artifact" not in data:
-        return None
-    return Artifact.model_validate(data["artifact"])

--- a/src/bearagent/application/run_queries.py
+++ b/src/bearagent/application/run_queries.py
@@ -1,0 +1,157 @@
+"""Application queries over committed Run facts."""
+
+from pydantic import ValidationError
+
+from bearagent.domain.artifacts import Artifact, artifact_from_tool_result_data
+from bearagent.domain.errors import BearAgentError, ErrorCategory, ErrorCode, ErrorInfo
+from bearagent.domain.events import Event
+from bearagent.domain.ids import RunId
+from bearagent.domain.queries import EventPage, RunInspection
+from bearagent.domain.run_events import ToolCallCompletedPayloadV2, parse_run_event_payload
+from bearagent.domain.runs import RunState
+from bearagent.ports.store import (
+    DEFAULT_EVENT_QUERY_LIMIT,
+    MAX_EVENT_QUERY_LIMIT,
+    EventStore,
+    validate_event_query,
+)
+
+MAX_INSPECT_EVENTS = MAX_EVENT_QUERY_LIMIT
+
+
+class RunQueryError(BearAgentError):
+    """A safe failure while reading committed Run facts."""
+
+
+class RunQueryService:
+    """Build reusable query results without knowing the persistence adapter."""
+
+    def __init__(self, event_store: EventStore) -> None:
+        self._event_store = event_store
+
+    async def inspect(self, run_id: RunId) -> RunInspection:
+        """Return the Run projection and its complete bounded Artifact set."""
+        state = await self._require_run(run_id)
+        # A partial Artifact list would look complete to callers, so fail closed
+        # before scanning when the committed history exceeds the trusted bound.
+        if state.last_sequence > MAX_INSPECT_EVENTS:
+            raise RunQueryError(
+                ErrorInfo(
+                    category=ErrorCategory.VALIDATION,
+                    code=ErrorCode.QUERY_LIMIT_EXCEEDED,
+                    message="Run Event history exceeds the inspect boundary.",
+                )
+            )
+
+        events: list[Event] = []
+        after_sequence = 0
+        while after_sequence < state.last_sequence:
+            remaining = state.last_sequence - after_sequence
+            page_limit = min(DEFAULT_EVENT_QUERY_LIMIT, remaining)
+            page = await self._event_store.list_events(
+                run_id,
+                after_sequence=after_sequence,
+                limit=page_limit,
+            )
+            if not page:
+                raise _invalid_history()
+            expected_sequences = tuple(range(after_sequence + 1, after_sequence + 1 + len(page)))
+            if (
+                len(page) > page_limit
+                or tuple(event.sequence for event in page) != expected_sequences
+                or page[-1].sequence > state.last_sequence
+            ):
+                raise _invalid_history()
+            events.extend(page)
+            after_sequence = page[-1].sequence
+
+        if len(events) != state.last_sequence:
+            raise _invalid_history()
+
+        artifacts: list[Artifact] = []
+        try:
+            for event in events:
+                payload = parse_run_event_payload(event)
+                if not isinstance(payload, ToolCallCompletedPayloadV2):
+                    continue
+                artifact = artifact_from_tool_result_data(
+                    payload.execution.request.name,
+                    payload.execution.result.data,
+                )
+                if artifact is not None:
+                    artifacts.append(artifact)
+            return RunInspection(
+                run_id=run_id,
+                state=state,
+                artifacts=tuple(artifacts),
+            )
+        except (KeyError, ValidationError, ValueError) as error:
+            raise _invalid_history(cause=error) from error
+
+    async def events(
+        self,
+        run_id: RunId,
+        *,
+        after_sequence: int = 0,
+        limit: int = DEFAULT_EVENT_QUERY_LIMIT,
+    ) -> EventPage:
+        """Return one bounded Event page from a consistent committed prefix."""
+        try:
+            validate_event_query(after_sequence, limit)
+        except ValueError as error:
+            raise RunQueryError(
+                ErrorInfo(
+                    category=ErrorCategory.VALIDATION,
+                    code=ErrorCode.INVALID_INPUT,
+                    message="Event query pagination is invalid.",
+                ),
+                cause=error,
+            ) from error
+
+        state = await self._require_run(run_id)
+        available = max(0, state.last_sequence - after_sequence)
+        query_limit = min(limit, available) if available else 0
+        events = (
+            await self._event_store.list_events(
+                run_id,
+                after_sequence=after_sequence,
+                limit=query_limit,
+            )
+            if query_limit
+            else ()
+        )
+        next_after_sequence = events[-1].sequence if events else after_sequence
+        try:
+            return EventPage(
+                run_id=run_id,
+                after_sequence=after_sequence,
+                limit=limit,
+                events=events,
+                next_after_sequence=next_after_sequence,
+                has_more=next_after_sequence < state.last_sequence,
+            )
+        except ValidationError as error:
+            raise _invalid_history(cause=error) from error
+
+    async def _require_run(self, run_id: RunId) -> RunState:
+        state = await self._event_store.get_run(run_id)
+        if state is None:
+            raise RunQueryError(
+                ErrorInfo(
+                    category=ErrorCategory.VALIDATION,
+                    code=ErrorCode.RUN_NOT_FOUND,
+                    message="Run was not found.",
+                )
+            )
+        return state
+
+
+def _invalid_history(*, cause: BaseException | None = None) -> RunQueryError:
+    return RunQueryError(
+        ErrorInfo(
+            category=ErrorCategory.VALIDATION,
+            code=ErrorCode.INVALID_EVENT,
+            message="Run Event history is incomplete or invalid.",
+        ),
+        cause=cause,
+    )

--- a/src/bearagent/bootstrap.py
+++ b/src/bearagent/bootstrap.py
@@ -1,5 +1,183 @@
-"""Composition root for production BearAgent adapters.
+"""Composition root for production BearAgent adapters."""
 
-P0 has no production runtime graph. Later phases must assemble adapters here
-instead of importing them from the runtime core.
-"""
+import asyncio
+import json
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from bearagent.adapters.model import OpenAIResponsesProvider
+from bearagent.adapters.sqlite import SqliteEventStore
+from bearagent.adapters.tools import build_workspace_tools
+from bearagent.application import AgentLoop, RunQueryService
+from bearagent.domain.agent import RunProfile
+from bearagent.domain.errors import BearAgentError, ErrorCategory, ErrorCode, ErrorInfo
+from bearagent.domain.ids import IdGenerator
+from bearagent.ports.model import ModelProvider
+from bearagent.runtime.policy import FixedToolPolicy
+from bearagent.runtime.tool_executor import ToolExecutor
+from bearagent.runtime.tool_registry import ToolRegistry
+
+MAX_RUN_PROFILE_BYTES = 128 * 1_024
+_WINDOWS_REPARSE_POINT = 0x400
+
+
+class BootstrapError(BearAgentError):
+    """A safe failure while validating configuration or assembling adapters."""
+
+
+@dataclass(frozen=True, slots=True)
+class RunServices:
+    """Production services sharing one initialized durable EventStore."""
+
+    profile: RunProfile
+    agent_loop: AgentLoop
+    queries: RunQueryService
+
+
+def load_run_profile(profile_path: str | os.PathLike[str]) -> RunProfile:
+    """Load one bounded UTF-8 JSON profile without accepting links or secrets."""
+    path = Path(profile_path)
+    try:
+        raw = _read_bounded_regular_file(path, max_bytes=MAX_RUN_PROFILE_BYTES)
+        decoded = json.loads(raw.decode("utf-8"))
+        return RunProfile.model_validate(decoded)
+    except (
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        ValidationError,
+        ValueError,
+    ) as error:
+        raise BootstrapError(
+            ErrorInfo(
+                category=ErrorCategory.VALIDATION,
+                code=ErrorCode.INVALID_INPUT,
+                message="Run profile is missing or invalid.",
+            ),
+            cause=error,
+        ) from error
+
+
+async def build_run_services(
+    *,
+    profile_path: str | os.PathLike[str],
+    workspace_path: str | os.PathLike[str],
+    database_path: str | os.PathLike[str],
+    model_provider: ModelProvider | None = None,
+    id_generator: IdGenerator | None = None,
+) -> RunServices:
+    """Validate inputs, initialize SQLite, and assemble the production Run graph."""
+    profile = load_run_profile(profile_path)
+    try:
+        available_tools = build_workspace_tools(workspace_path, id_generator=id_generator)
+        available_names = {tool.spec.name for tool in available_tools}
+        configured_names = set(profile.agent_config.tool_names)
+        if not configured_names <= available_names:
+            raise ValueError("profile references an unavailable Tool")
+        # Only configured Tools enter the registry. Policy still defaults to deny,
+        # while the Provider never sees definitions outside this trusted profile.
+        registry = ToolRegistry(
+            tool for tool in available_tools if tool.spec.name in configured_names
+        )
+        policy = FixedToolPolicy(profile.agent_config.tool_names)
+        executor = ToolExecutor(registry, policy)
+        provider = model_provider if model_provider is not None else OpenAIResponsesProvider()
+    except Exception as error:
+        raise BootstrapError(
+            ErrorInfo(
+                category=ErrorCategory.VALIDATION,
+                code=ErrorCode.INVALID_INPUT,
+                message="Run services could not be configured.",
+            ),
+            cause=error,
+        ) from error
+
+    store = SqliteEventStore(Path(database_path))
+    await store.initialize()
+    return RunServices(
+        profile=profile,
+        agent_loop=AgentLoop(
+            model_provider=provider,
+            event_store=store,
+            tool_executor=executor,
+            id_generator=id_generator,
+        ),
+        queries=RunQueryService(store),
+    )
+
+
+async def build_run_query_service(
+    database_path: str | os.PathLike[str],
+) -> RunQueryService:
+    """Open an existing ordinary database without creating a missing one."""
+    try:
+        path = await asyncio.to_thread(_require_existing_database, database_path)
+    except (OSError, ValueError) as error:
+        raise BootstrapError(
+            ErrorInfo(
+                category=ErrorCategory.PERSISTENCE,
+                code=ErrorCode.PERSISTENCE_ERROR,
+                message="Run database is missing or invalid.",
+            ),
+            cause=error,
+        ) from error
+
+    store = SqliteEventStore(path)
+    await store.initialize()
+    return RunQueryService(store)
+
+
+def _is_link_like(path: Path, path_stat: os.stat_result) -> bool:
+    if stat.S_ISLNK(path_stat.st_mode):
+        return True
+    attributes = getattr(path_stat, "st_file_attributes", 0)
+    if attributes & _WINDOWS_REPARSE_POINT:
+        return True
+    try:
+        return path.is_junction()
+    except OSError:
+        return True
+
+
+def _require_existing_database(database_path: str | os.PathLike[str]) -> Path:
+    path = Path(database_path)
+    path_stat = path.lstat()
+    if _is_link_like(path, path_stat) or not stat.S_ISREG(path_stat.st_mode):
+        raise ValueError("database must be an ordinary file")
+    return path
+
+
+def _read_bounded_regular_file(path: Path, *, max_bytes: int) -> bytes:
+    initial = path.lstat()
+    if _is_link_like(path, initial) or not stat.S_ISREG(initial.st_mode):
+        raise ValueError("file must be ordinary")
+    if initial.st_size > max_bytes:
+        raise ValueError("file exceeds the byte limit")
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    with os.fdopen(descriptor, "rb") as handle:
+        opened_before = os.fstat(handle.fileno())
+        if not os.path.samestat(initial, opened_before) or not stat.S_ISREG(opened_before.st_mode):
+            raise ValueError("file changed during open")
+        content = handle.read(max_bytes + 1)
+        opened_after = os.fstat(handle.fileno())
+
+    current = path.lstat()
+    if (
+        len(content) > max_bytes
+        or _is_link_like(path, current)
+        or not os.path.samestat(opened_before, opened_after)
+        or not os.path.samestat(opened_after, current)
+        or not _same_file_snapshot(opened_before, opened_after)
+    ):
+        raise ValueError("file changed while reading")
+    return content
+
+
+def _same_file_snapshot(first: os.stat_result, second: os.stat_result) -> bool:
+    return first.st_size == second.st_size and first.st_mtime_ns == second.st_mtime_ns

--- a/src/bearagent/domain/__init__.py
+++ b/src/bearagent/domain/__init__.py
@@ -6,9 +6,15 @@ from bearagent.domain.agent import (
     ContextBuildResult,
     ModelPricing,
     RunInput,
+    RunProfile,
     RunResult,
 )
-from bearagent.domain.artifacts import Artifact, ArtifactEncoding, ArtifactKind
+from bearagent.domain.artifacts import (
+    Artifact,
+    ArtifactEncoding,
+    ArtifactKind,
+    artifact_from_tool_result_data,
+)
 from bearagent.domain.errors import BearAgentError, ErrorCategory, ErrorCode, ErrorInfo
 from bearagent.domain.events import Event
 from bearagent.domain.ids import (
@@ -44,6 +50,7 @@ from bearagent.domain.model import (
     ModelToolDefinition,
     ModelUsage,
 )
+from bearagent.domain.queries import EventPage, RunInspection
 from bearagent.domain.run_events import (
     ModelCallCompletedPayload,
     ModelCallCompletedPayloadV2,
@@ -105,6 +112,7 @@ __all__ = [
     "ArtifactEncoding",
     "ArtifactId",
     "ArtifactKind",
+    "artifact_from_tool_result_data",
     "BearAgentError",
     "BudgetDimension",
     "BudgetExhaustion",
@@ -118,6 +126,7 @@ __all__ = [
     "ErrorCode",
     "Event",
     "EventId",
+    "EventPage",
     "ErrorInfo",
     "IdGenerator",
     "Message",
@@ -153,6 +162,8 @@ __all__ = [
     "RunFailedPayload",
     "RunFailedPayloadV2",
     "RunInput",
+    "RunInspection",
+    "RunProfile",
     "RunResult",
     "RunStartedPayload",
     "RunStartedPayloadV2",

--- a/src/bearagent/domain/agent.py
+++ b/src/bearagent/domain/agent.py
@@ -1,6 +1,6 @@
 """Versioned Agent configuration and application boundary data."""
 
-from typing import Self
+from typing import Literal, Self
 
 from pydantic import Field, field_validator, model_validator
 
@@ -144,6 +144,14 @@ class RunInput(DomainModel):
         if not value.strip():
             raise ValueError("objective must not be blank")
         return value
+
+
+class RunProfile(DomainModel):
+    """Versioned, non-secret configuration loaded by a trusted interface."""
+
+    schema_version: Literal[1] = 1
+    agent_config: AgentConfig
+    budget_limits: BudgetLimits
 
 
 class RunResult(DomainModel):

--- a/src/bearagent/domain/artifacts.py
+++ b/src/bearagent/domain/artifacts.py
@@ -1,5 +1,6 @@
 """Provider-neutral metadata for retrievable Run outputs."""
 
+from collections.abc import Mapping
 from enum import StrEnum
 
 from pydantic import Field, field_validator
@@ -43,3 +44,13 @@ class Artifact(DomainModel):
         if any(ord(character) < 32 or ord(character) == 127 for character in value):
             raise ValueError("Artifact path contains a control character")
         return value
+
+
+def artifact_from_tool_result_data(
+    tool_name: str,
+    data: Mapping[str, object],
+) -> Artifact | None:
+    """Recover committed workspace.write metadata without granting file access."""
+    if tool_name != "workspace.write" or "artifact" not in data:
+        return None
+    return Artifact.model_validate(data["artifact"])

--- a/src/bearagent/domain/errors.py
+++ b/src/bearagent/domain/errors.py
@@ -54,6 +54,8 @@ class ErrorCode(StrEnum):
     INVALID_INPUT = "invalid_input"
     INVALID_EVENT = "invalid_event"
     INVALID_STATE_TRANSITION = "invalid_state_transition"
+    RUN_NOT_FOUND = "run_not_found"
+    QUERY_LIMIT_EXCEEDED = "query_limit_exceeded"
     BUDGET_EXHAUSTED = "budget_exhausted"
     PROVIDER_ERROR = "provider_error"
     PROVIDER_TIMEOUT = "provider_timeout"
@@ -84,6 +86,8 @@ _CODE_CATEGORIES = {
     ErrorCode.INVALID_INPUT: ErrorCategory.VALIDATION,
     ErrorCode.INVALID_EVENT: ErrorCategory.VALIDATION,
     ErrorCode.INVALID_STATE_TRANSITION: ErrorCategory.VALIDATION,
+    ErrorCode.RUN_NOT_FOUND: ErrorCategory.VALIDATION,
+    ErrorCode.QUERY_LIMIT_EXCEEDED: ErrorCategory.VALIDATION,
     ErrorCode.BUDGET_EXHAUSTED: ErrorCategory.BUDGET,
     ErrorCode.PROVIDER_ERROR: ErrorCategory.PROVIDER,
     ErrorCode.PROVIDER_TIMEOUT: ErrorCategory.PROVIDER,

--- a/src/bearagent/domain/queries.py
+++ b/src/bearagent/domain/queries.py
@@ -1,0 +1,62 @@
+"""Provider-neutral result contracts for querying committed Run facts."""
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from bearagent.domain._base import DomainModel
+from bearagent.domain.artifacts import Artifact
+from bearagent.domain.events import Event
+from bearagent.domain.ids import RunId
+from bearagent.domain.runs import RunState
+
+MAX_EVENT_PAGE_LIMIT = 10_000
+MAX_EVENT_SEQUENCE = 9_223_372_036_854_775_807
+
+
+class RunInspection(DomainModel):
+    """One trusted Run projection plus outputs recovered from committed Events."""
+
+    run_id: RunId
+    state: RunState
+    artifacts: tuple[Artifact, ...] = ()
+
+    @model_validator(mode="after")
+    def require_one_consistent_run(self) -> Self:
+        if self.state.run_id != self.run_id:
+            raise ValueError("inspection state must belong to run_id")
+        artifact_ids = [artifact.artifact_id for artifact in self.artifacts]
+        if len(artifact_ids) != len(set(artifact_ids)):
+            raise ValueError("inspection artifact identities must be unique")
+        return self
+
+
+class EventPage(DomainModel):
+    """A bounded, contiguous page of committed Events for one Run."""
+
+    run_id: RunId
+    after_sequence: int = Field(ge=0, le=MAX_EVENT_SEQUENCE, strict=True)
+    limit: int = Field(ge=1, le=MAX_EVENT_PAGE_LIMIT, strict=True)
+    events: tuple[Event, ...] = ()
+    next_after_sequence: int = Field(ge=0, le=MAX_EVENT_SEQUENCE, strict=True)
+    has_more: bool
+
+    @model_validator(mode="after")
+    def require_stable_contiguous_cursor(self) -> Self:
+        if len(self.events) > self.limit:
+            raise ValueError("event page exceeds its requested limit")
+        if any(event.run_id != self.run_id for event in self.events):
+            raise ValueError("all events must belong to run_id")
+
+        expected_sequences = tuple(
+            range(self.after_sequence + 1, self.after_sequence + 1 + len(self.events))
+        )
+        if tuple(event.sequence for event in self.events) != expected_sequences:
+            raise ValueError("event page must be ordered and contiguous")
+
+        expected_cursor = self.events[-1].sequence if self.events else self.after_sequence
+        if self.next_after_sequence != expected_cursor:
+            raise ValueError("next_after_sequence must identify the last returned event")
+        if self.has_more and not self.events:
+            raise ValueError("an empty event page cannot report more results")
+        return self

--- a/src/bearagent/domain/schema.py
+++ b/src/bearagent/domain/schema.py
@@ -8,6 +8,7 @@ from bearagent.domain.agent import (
     ContextBuildResult,
     ModelPricing,
     RunInput,
+    RunProfile,
     RunResult,
 )
 from bearagent.domain.artifacts import Artifact
@@ -33,6 +34,7 @@ from bearagent.domain.model import (
     ModelToolDefinition,
     ModelUsage,
 )
+from bearagent.domain.queries import EventPage, RunInspection
 from bearagent.domain.run_events import (
     ModelCallCompletedPayload,
     ModelCallCompletedPayloadV2,
@@ -90,6 +92,7 @@ PUBLIC_SCHEMA_MODELS: tuple[type[BaseModel], ...] = (
     ContextBuildReport,
     ErrorInfo,
     Event,
+    EventPage,
     EventId,
     Message,
     ModelCompleted,
@@ -116,6 +119,8 @@ PUBLIC_SCHEMA_MODELS: tuple[type[BaseModel], ...] = (
     RunFailedPayload,
     RunFailedPayloadV2,
     RunInput,
+    RunInspection,
+    RunProfile,
     RunStartedPayload,
     RunStartedPayloadV2,
     RunState,

--- a/src/bearagent/interfaces/cli/contracts.py
+++ b/src/bearagent/interfaces/cli/contracts.py
@@ -1,0 +1,58 @@
+"""Versioned machine-readable contracts emitted by the CLI."""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+from bearagent.domain._base import DomainModel
+from bearagent.domain.agent import RunResult
+from bearagent.domain.errors import ErrorInfo
+from bearagent.domain.queries import EventPage, RunInspection
+
+
+class RunCommandOutput(DomainModel):
+    """Successful or terminal result of ``bearagent run OBJECTIVE``."""
+
+    schema_version: Literal[1] = 1
+    command: Literal["run"] = "run"
+    result: RunResult
+
+
+class InspectCommandOutput(DomainModel):
+    """Result of ``bearagent run inspect RUN_ID``."""
+
+    schema_version: Literal[1] = 1
+    command: Literal["inspect"] = "inspect"
+    result: RunInspection
+
+
+class EventsCommandOutput(DomainModel):
+    """Result of ``bearagent run events RUN_ID``."""
+
+    schema_version: Literal[1] = 1
+    command: Literal["events"] = "events"
+    result: EventPage
+
+
+class CommandErrorOutput(DomainModel):
+    """Safe failure object shared by all Run commands."""
+
+    schema_version: Literal[1] = 1
+    command: Literal["run", "inspect", "events"]
+    error: ErrorInfo
+
+
+PUBLIC_CLI_SCHEMA_MODELS: tuple[type[BaseModel], ...] = (
+    CommandErrorOutput,
+    EventsCommandOutput,
+    InspectCommandOutput,
+    RunCommandOutput,
+)
+
+
+def public_cli_schemas() -> dict[str, dict[str, object]]:
+    """Return deterministic JSON schemas keyed by output model name."""
+    return {
+        model.__name__: model.model_json_schema(mode="serialization")
+        for model in sorted(PUBLIC_CLI_SCHEMA_MODELS, key=lambda item: item.__name__)
+    }

--- a/src/bearagent/interfaces/cli/main.py
+++ b/src/bearagent/interfaces/cli/main.py
@@ -1,14 +1,40 @@
-"""P0 command-line interface and environment diagnostics."""
+"""BearAgent command-line interface and production Run entrypoint."""
 
+import asyncio
 import json
 import platform
 import sys
 from pathlib import Path
-from typing import Annotated, Literal, TypedDict
+from typing import Annotated, Literal, NoReturn, TypedDict
 
 import typer
+from pydantic import ValidationError
+from typer import _click
+from typer.core import TyperGroup
 
 from bearagent import package_version
+from bearagent.bootstrap import build_run_query_service, build_run_services
+from bearagent.domain.agent import MAX_OBJECTIVE_CHARS, RunInput
+from bearagent.domain.errors import BearAgentError, ErrorCategory, ErrorCode, ErrorInfo
+from bearagent.domain.ids import RunId, SessionId
+from bearagent.domain.runs import RunStatus
+from bearagent.interfaces.cli.contracts import (
+    CommandErrorOutput,
+    EventsCommandOutput,
+    InspectCommandOutput,
+    RunCommandOutput,
+)
+from bearagent.interfaces.cli.renderers import (
+    render_error,
+    render_events,
+    render_inspection,
+    render_json,
+    render_run,
+)
+
+DEFAULT_PROFILE_PATH = Path("data/p1-run-profile.json")
+DEFAULT_DATABASE_PATH = Path("data/bearagent.db")
+DEFAULT_WORKSPACE_PATH = Path(".")
 
 
 class DoctorReport(TypedDict):
@@ -22,12 +48,34 @@ class DoctorReport(TypedDict):
     working_directory: str
 
 
+class DefaultRunGroup(TyperGroup):
+    """Route unknown first tokens to the hidden objective command."""
+
+    def parse_args(self, ctx: _click.Context, args: list[str]) -> list[str]:
+        if args and args[0] not in self.commands and args[0] not in {"--help", "-h"}:
+            args = ["execute", *args]
+        return super().parse_args(ctx, args)
+
+
 app = typer.Typer(
     name="bearagent",
     help="Durable and secure personal AI Agent Runtime.",
     no_args_is_help=True,
     add_completion=False,
 )
+run_app = typer.Typer(
+    name="run",
+    cls=DefaultRunGroup,
+    help="Execute `bearagent run OBJECTIVE`, or inspect an existing durable Run.",
+    epilog=(
+        "Run options may appear before or after OBJECTIVE. "
+        "Use `bearagent run -- OBJECTIVE` when the objective is named inspect/events "
+        "or begins with a dash."
+    ),
+    no_args_is_help=True,
+    add_completion=False,
+)
+app.add_typer(run_app, name="run")
 
 
 def _version_callback(value: bool) -> None:
@@ -85,3 +133,184 @@ def doctor(
 
     if not report["python_supported"]:
         raise typer.Exit(code=1)
+
+
+@run_app.command("execute", hidden=True)
+def run_objective(
+    objective: Annotated[str, typer.Argument(help="The objective for this Run.")],
+    profile: Annotated[
+        Path,
+        typer.Option("--profile", help="Path to a version 1 Run profile."),
+    ] = DEFAULT_PROFILE_PATH,
+    workspace: Annotated[
+        Path,
+        typer.Option("--workspace", help="Workspace root available to Tools."),
+    ] = DEFAULT_WORKSPACE_PATH,
+    database: Annotated[
+        Path,
+        typer.Option("--database", help="SQLite EventStore path."),
+    ] = DEFAULT_DATABASE_PATH,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit one versioned JSON result."),
+    ] = False,
+) -> None:
+    """Execute one objective through the durable Agent Loop."""
+    try:
+        output = asyncio.run(
+            _execute_objective(
+                objective=objective,
+                profile=profile,
+                workspace=workspace,
+                database=database,
+            )
+        )
+    except (BearAgentError, ValidationError, ValueError, OSError) as error:
+        _exit_with_error("run", error, json_output=json_output)
+    except Exception as error:
+        _exit_with_error("run", error, json_output=json_output)
+
+    typer.echo(render_json(output) if json_output else render_run(output.result))
+    if output.result.state.status is RunStatus.FAILED:
+        raise typer.Exit(code=1)
+
+
+@run_app.command("inspect")
+def inspect_run(
+    run_id: Annotated[str, typer.Argument(help="UUID4 Run identifier.")],
+    database: Annotated[
+        Path,
+        typer.Option("--database", help="Existing SQLite EventStore path."),
+    ] = DEFAULT_DATABASE_PATH,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit one versioned JSON result."),
+    ] = False,
+) -> None:
+    """Show the reducer projection and committed Artifact metadata."""
+    try:
+        output = asyncio.run(_inspect_existing_run(run_id=run_id, database=database))
+    except (BearAgentError, ValidationError, ValueError, OSError) as error:
+        _exit_with_error("inspect", error, json_output=json_output)
+    except Exception as error:
+        _exit_with_error("inspect", error, json_output=json_output)
+    typer.echo(render_json(output) if json_output else render_inspection(output.result))
+
+
+@run_app.command("events")
+def list_run_events(
+    run_id: Annotated[str, typer.Argument(help="UUID4 Run identifier.")],
+    after_sequence: Annotated[
+        int,
+        typer.Option("--after-sequence", min=0, help="Return Events after this sequence."),
+    ] = 0,
+    limit: Annotated[
+        int,
+        typer.Option("--limit", min=1, max=10_000, help="Maximum Events to return."),
+    ] = 1_000,
+    database: Annotated[
+        Path,
+        typer.Option("--database", help="Existing SQLite EventStore path."),
+    ] = DEFAULT_DATABASE_PATH,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit one versioned JSON result."),
+    ] = False,
+) -> None:
+    """Show one bounded page of committed Event facts."""
+    try:
+        output = asyncio.run(
+            _list_existing_run_events(
+                run_id=run_id,
+                database=database,
+                after_sequence=after_sequence,
+                limit=limit,
+            )
+        )
+    except (BearAgentError, ValidationError, ValueError, OSError) as error:
+        _exit_with_error("events", error, json_output=json_output)
+    except Exception as error:
+        _exit_with_error("events", error, json_output=json_output)
+    typer.echo(render_json(output) if json_output else render_events(output.result))
+
+
+async def _execute_objective(
+    *,
+    objective: str,
+    profile: Path,
+    workspace: Path,
+    database: Path,
+) -> RunCommandOutput:
+    if not objective.strip() or len(objective) > MAX_OBJECTIVE_CHARS:
+        raise ValueError("objective is invalid")
+    services = await build_run_services(
+        profile_path=profile,
+        workspace_path=workspace,
+        database_path=database,
+    )
+    # stderr keeps JSON stdout machine-readable. "Allocated" deliberately does
+    # not claim RunCreated has committed yet.
+    run_id = RunId.new()
+    typer.echo(f"Allocated Run ID: {run_id}", err=True)
+    result = await services.agent_loop.run(
+        RunInput(
+            session_id=SessionId.new(),
+            objective=objective,
+            budget_limits=services.profile.budget_limits,
+            agent_config=services.profile.agent_config,
+        ),
+        run_id=run_id,
+    )
+    return RunCommandOutput(result=result)
+
+
+async def _inspect_existing_run(*, run_id: str, database: Path) -> InspectCommandOutput:
+    parsed_run_id = RunId.parse(run_id)
+    service = await build_run_query_service(database)
+    return InspectCommandOutput(result=await service.inspect(parsed_run_id))
+
+
+async def _list_existing_run_events(
+    *,
+    run_id: str,
+    database: Path,
+    after_sequence: int,
+    limit: int,
+) -> EventsCommandOutput:
+    parsed_run_id = RunId.parse(run_id)
+    service = await build_run_query_service(database)
+    return EventsCommandOutput(
+        result=await service.events(
+            parsed_run_id,
+            after_sequence=after_sequence,
+            limit=limit,
+        )
+    )
+
+
+def _exit_with_error(
+    command: Literal["run", "inspect", "events"],
+    error: BaseException,
+    *,
+    json_output: bool,
+) -> NoReturn:
+    info = _safe_error_info(error)
+    output = CommandErrorOutput(command=command, error=info)
+    typer.echo(render_json(output) if json_output else f"Error: {render_error(info)}")
+    raise typer.Exit(code=1)
+
+
+def _safe_error_info(error: BaseException) -> ErrorInfo:
+    if isinstance(error, BearAgentError):
+        return error.info
+    if isinstance(error, ValidationError | ValueError):
+        return ErrorInfo(
+            category=ErrorCategory.VALIDATION,
+            code=ErrorCode.INVALID_INPUT,
+            message="Command input is invalid.",
+        )
+    return ErrorInfo(
+        category=ErrorCategory.INTERNAL,
+        code=ErrorCode.INTERNAL_ERROR,
+        message="Command could not be completed.",
+    )

--- a/src/bearagent/interfaces/cli/renderers.py
+++ b/src/bearagent/interfaces/cli/renderers.py
@@ -1,0 +1,108 @@
+"""Bounded human and JSON rendering for Run CLI results."""
+
+import json
+
+from pydantic import BaseModel
+
+from bearagent.domain.agent import RunResult
+from bearagent.domain.errors import ErrorInfo
+from bearagent.domain.queries import EventPage, RunInspection
+
+MAX_HUMAN_FINAL_TEXT_CHARS = 50_000
+
+
+def render_json(value: BaseModel) -> str:
+    """Serialize exactly one stable JSON object."""
+    return json.dumps(
+        value.model_dump(mode="json"),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def render_run(result: RunResult) -> str:
+    """Render one terminal Run without exposing raw adapter data."""
+    usage = result.state.budget_usage
+    lines = [
+        f"Run ID: {result.run_id}",
+        f"Status: {result.state.status.value}",
+        (
+            "Usage: "
+            f"models={usage.model_iterations}, tokens={usage.tokens}, "
+            f"cost_microusd={usage.cost_microusd}, tools={usage.tool_calls}"
+        ),
+    ]
+    for activity in result.state.activities:
+        label = activity.kind.value
+        if activity.tool_name is not None:
+            label = f"{label}:{activity.tool_name}"
+        lines.append(f"Activity: {label} {activity.status.value}")
+    for artifact in result.artifacts:
+        lines.append(
+            f"Artifact: {artifact.path} ({artifact.size_bytes} bytes, sha256={artifact.sha256})"
+        )
+    if result.final_text is not None:
+        lines.extend(("Final text:", _bounded_text(result.final_text)))
+    if result.state.terminal_error is not None:
+        lines.append(f"Error: {render_error(result.state.terminal_error)}")
+    return "\n".join(lines)
+
+
+def render_inspection(inspection: RunInspection) -> str:
+    """Render the complete reducer projection and committed Artifact metadata."""
+    state = inspection.state
+    usage = state.budget_usage
+    lines = [
+        f"Run ID: {inspection.run_id}",
+        f"Status: {state.status.value}",
+        f"Last sequence: {state.last_sequence}",
+        (
+            "Usage: "
+            f"models={usage.model_iterations}, tokens={usage.tokens}, "
+            f"cost_microusd={usage.cost_microusd}, tools={usage.tool_calls}"
+        ),
+    ]
+    for activity in state.activities:
+        label = activity.kind.value
+        if activity.tool_name is not None:
+            label = f"{label}:{activity.tool_name}"
+        lines.append(f"Activity: {label} {activity.status.value}")
+    for artifact in inspection.artifacts:
+        lines.append(
+            f"Artifact: {artifact.path} ({artifact.size_bytes} bytes, sha256={artifact.sha256})"
+        )
+    if state.terminal_error is not None:
+        lines.append(f"Error: {render_error(state.terminal_error)}")
+    return "\n".join(lines)
+
+
+def render_events(page: EventPage) -> str:
+    """Render one-line Event summaries without printing payloads."""
+    lines = [
+        f"Run ID: {page.run_id}",
+        (
+            f"Events after {page.after_sequence}: {len(page.events)} "
+            f"(next={page.next_after_sequence}, has_more={str(page.has_more).lower()})"
+        ),
+    ]
+    lines.extend(
+        (
+            f"{event.sequence} {event.occurred_at.isoformat()} "
+            f"{event.event_type} v{event.schema_version}"
+        )
+        for event in page.events
+    )
+    return "\n".join(lines)
+
+
+def render_error(error: ErrorInfo) -> str:
+    """Render only normalized safe ErrorInfo fields."""
+    retry = " retryable" if error.retryable else ""
+    return f"{error.code.value} ({error.category.value}{retry}): {error.message}"
+
+
+def _bounded_text(value: str) -> str:
+    if len(value) <= MAX_HUMAN_FINAL_TEXT_CHARS:
+        return value
+    return value[:MAX_HUMAN_FINAL_TEXT_CHARS] + "\n[output truncated]"

--- a/tests/contract/snapshots/cli_schemas.json
+++ b/tests/contract/snapshots/cli_schemas.json
@@ -1,0 +1,1428 @@
+{
+  "CommandErrorOutput": {
+    "$defs": {
+      "ErrorCategory": {
+        "description": "Stable high-level class used for handling and aggregation.",
+        "enum": [
+          "validation",
+          "budget",
+          "provider",
+          "tool",
+          "persistence",
+          "internal"
+        ],
+        "title": "ErrorCategory",
+        "type": "string"
+      },
+      "ErrorCode": {
+        "description": "Initial stable error codes; later Features may add specific codes.",
+        "enum": [
+          "invalid_input",
+          "invalid_event",
+          "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
+          "budget_exhausted",
+          "provider_error",
+          "provider_timeout",
+          "provider_rate_limited",
+          "provider_unavailable",
+          "provider_authentication",
+          "provider_permission_denied",
+          "provider_invalid_request",
+          "provider_refused",
+          "provider_protocol_error",
+          "tool_not_found",
+          "tool_invalid_input",
+          "tool_permission_denied",
+          "tool_timeout",
+          "tool_output_too_large",
+          "tool_error",
+          "workspace_path_denied",
+          "workspace_not_found",
+          "workspace_wrong_type",
+          "workspace_not_text",
+          "workspace_limit_exceeded",
+          "workspace_access_failed",
+          "persistence_error",
+          "internal_error"
+        ],
+        "title": "ErrorCode",
+        "type": "string"
+      },
+      "ErrorInfo": {
+        "additionalProperties": false,
+        "description": "Serializable error data that is safe to expose and persist.",
+        "properties": {
+          "category": {
+            "$ref": "#/$defs/ErrorCategory"
+          },
+          "code": {
+            "$ref": "#/$defs/ErrorCode"
+          },
+          "message": {
+            "maxLength": 1000,
+            "minLength": 1,
+            "title": "Message",
+            "type": "string"
+          },
+          "retryable": {
+            "default": false,
+            "title": "Retryable",
+            "type": "boolean"
+          },
+          "details": {
+            "additionalProperties": {
+              "$ref": "#/$defs/SafeDetailValue"
+            },
+            "maxProperties": 32,
+            "title": "Details",
+            "type": "object"
+          }
+        },
+        "required": [
+          "category",
+          "code",
+          "message"
+        ],
+        "title": "ErrorInfo",
+        "type": "object"
+      },
+      "SafeDetailValue": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "description": "Safe failure object shared by all Run commands.",
+    "properties": {
+      "schema_version": {
+        "const": 1,
+        "default": 1,
+        "title": "Schema Version",
+        "type": "integer"
+      },
+      "command": {
+        "enum": [
+          "run",
+          "inspect",
+          "events"
+        ],
+        "title": "Command",
+        "type": "string"
+      },
+      "error": {
+        "$ref": "#/$defs/ErrorInfo"
+      }
+    },
+    "required": [
+      "command",
+      "error"
+    ],
+    "title": "CommandErrorOutput",
+    "type": "object"
+  },
+  "EventsCommandOutput": {
+    "$defs": {
+      "CausationId": {
+        "description": "Identify the command, Activity, or Event that caused a fact.",
+        "format": "uuid4",
+        "title": "CausationId",
+        "type": "string"
+      },
+      "CorrelationId": {
+        "description": "Correlate facts that belong to one diagnostic flow.",
+        "format": "uuid4",
+        "title": "CorrelationId",
+        "type": "string"
+      },
+      "Event": {
+        "additionalProperties": false,
+        "description": "Common envelope for an immutable domain fact.",
+        "properties": {
+          "event_id": {
+            "$ref": "#/$defs/EventId"
+          },
+          "run_id": {
+            "$ref": "#/$defs/RunId"
+          },
+          "sequence": {
+            "minimum": 1,
+            "title": "Sequence",
+            "type": "integer"
+          },
+          "event_type": {
+            "pattern": "^[A-Z][A-Za-z0-9]{0,127}$",
+            "title": "Event Type",
+            "type": "string"
+          },
+          "schema_version": {
+            "default": 1,
+            "minimum": 1,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "occurred_at": {
+            "format": "date-time",
+            "title": "Occurred At",
+            "type": "string"
+          },
+          "causation_id": {
+            "$ref": "#/$defs/CausationId"
+          },
+          "correlation_id": {
+            "$ref": "#/$defs/CorrelationId"
+          },
+          "payload": {
+            "additionalProperties": {
+              "$ref": "#/$defs/JsonValue"
+            },
+            "title": "Payload",
+            "type": "object"
+          }
+        },
+        "required": [
+          "event_id",
+          "run_id",
+          "sequence",
+          "event_type",
+          "occurred_at",
+          "causation_id",
+          "correlation_id"
+        ],
+        "title": "Event",
+        "type": "object"
+      },
+      "EventId": {
+        "description": "Identify one immutable persisted fact.",
+        "format": "uuid4",
+        "title": "EventId",
+        "type": "string"
+      },
+      "EventPage": {
+        "additionalProperties": false,
+        "description": "A bounded, contiguous page of committed Events for one Run.",
+        "properties": {
+          "run_id": {
+            "$ref": "#/$defs/RunId"
+          },
+          "after_sequence": {
+            "maximum": 9223372036854775807,
+            "minimum": 0,
+            "title": "After Sequence",
+            "type": "integer"
+          },
+          "limit": {
+            "maximum": 10000,
+            "minimum": 1,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "events": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/Event"
+            },
+            "title": "Events",
+            "type": "array"
+          },
+          "next_after_sequence": {
+            "maximum": 9223372036854775807,
+            "minimum": 0,
+            "title": "Next After Sequence",
+            "type": "integer"
+          },
+          "has_more": {
+            "title": "Has More",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "run_id",
+          "after_sequence",
+          "limit",
+          "next_after_sequence",
+          "has_more"
+        ],
+        "title": "EventPage",
+        "type": "object"
+      },
+      "JsonValue": {},
+      "RunId": {
+        "description": "Identify one user-request execution.",
+        "format": "uuid4",
+        "title": "RunId",
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Result of ``bearagent run events RUN_ID``.",
+    "properties": {
+      "schema_version": {
+        "const": 1,
+        "default": 1,
+        "title": "Schema Version",
+        "type": "integer"
+      },
+      "command": {
+        "const": "events",
+        "default": "events",
+        "title": "Command",
+        "type": "string"
+      },
+      "result": {
+        "$ref": "#/$defs/EventPage"
+      }
+    },
+    "required": [
+      "result"
+    ],
+    "title": "EventsCommandOutput",
+    "type": "object"
+  },
+  "InspectCommandOutput": {
+    "$defs": {
+      "ActivityId": {
+        "description": "Identify one model or tool operation.",
+        "format": "uuid4",
+        "title": "ActivityId",
+        "type": "string"
+      },
+      "ActivityKind": {
+        "description": "Kinds of serial operations tracked by the P1 reducer.",
+        "enum": [
+          "model",
+          "tool"
+        ],
+        "title": "ActivityKind",
+        "type": "string"
+      },
+      "ActivityState": {
+        "additionalProperties": false,
+        "description": "Immutable state for one model or Tool operation.",
+        "properties": {
+          "activity_id": {
+            "$ref": "#/$defs/ActivityId"
+          },
+          "kind": {
+            "$ref": "#/$defs/ActivityKind"
+          },
+          "status": {
+            "$ref": "#/$defs/ActivityStatus"
+          },
+          "requested_at": {
+            "format": "date-time",
+            "title": "Requested At",
+            "type": "string"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Started At"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Completed At"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ErrorInfo"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "model_call_id": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ModelCallId"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "tool_call_id": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ToolCallId"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "tool_name": {
+            "anyOf": [
+              {
+                "pattern": "^[A-Za-z][A-Za-z0-9_.-]{0,127}$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Tool Name"
+          }
+        },
+        "required": [
+          "activity_id",
+          "kind",
+          "status",
+          "requested_at"
+        ],
+        "title": "ActivityState",
+        "type": "object"
+      },
+      "ActivityStatus": {
+        "description": "P1 Activity lifecycle states.",
+        "enum": [
+          "pending",
+          "running",
+          "succeeded",
+          "failed"
+        ],
+        "title": "ActivityStatus",
+        "type": "string"
+      },
+      "Artifact": {
+        "additionalProperties": false,
+        "description": "Bounded metadata for one retrievable output, without access authority.",
+        "properties": {
+          "artifact_id": {
+            "$ref": "#/$defs/ArtifactId"
+          },
+          "path": {
+            "maxLength": 4096,
+            "minLength": 1,
+            "title": "Path",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/$defs/ArtifactKind"
+          },
+          "encoding": {
+            "$ref": "#/$defs/ArtifactEncoding"
+          },
+          "size_bytes": {
+            "minimum": 0,
+            "title": "Size Bytes",
+            "type": "integer"
+          },
+          "sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Sha256",
+            "type": "string"
+          }
+        },
+        "required": [
+          "artifact_id",
+          "path",
+          "kind",
+          "encoding",
+          "size_bytes",
+          "sha256"
+        ],
+        "title": "Artifact",
+        "type": "object"
+      },
+      "ArtifactEncoding": {
+        "description": "Encoding used by a text Artifact.",
+        "enum": [
+          "utf-8"
+        ],
+        "title": "ArtifactEncoding",
+        "type": "string"
+      },
+      "ArtifactId": {
+        "description": "Identify one retrievable Run output.",
+        "format": "uuid4",
+        "title": "ArtifactId",
+        "type": "string"
+      },
+      "ArtifactKind": {
+        "description": "Stable high-level representation of one Artifact.",
+        "enum": [
+          "text"
+        ],
+        "title": "ArtifactKind",
+        "type": "string"
+      },
+      "BudgetLimits": {
+        "additionalProperties": false,
+        "description": "Finite limits selected by a trusted Run creation boundary.",
+        "properties": {
+          "max_model_iterations": {
+            "maximum": 100000,
+            "minimum": 0,
+            "title": "Max Model Iterations",
+            "type": "integer"
+          },
+          "max_tokens": {
+            "maximum": 10000000000,
+            "minimum": 0,
+            "title": "Max Tokens",
+            "type": "integer"
+          },
+          "max_cost_microusd": {
+            "maximum": 1000000000000,
+            "minimum": 0,
+            "title": "Max Cost Microusd",
+            "type": "integer"
+          },
+          "max_wall_time_ms": {
+            "maximum": 2678400000,
+            "minimum": 0,
+            "title": "Max Wall Time Ms",
+            "type": "integer"
+          },
+          "max_tool_calls": {
+            "maximum": 1000000,
+            "minimum": 0,
+            "title": "Max Tool Calls",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "max_model_iterations",
+          "max_tokens",
+          "max_cost_microusd",
+          "max_wall_time_ms",
+          "max_tool_calls"
+        ],
+        "title": "BudgetLimits",
+        "type": "object"
+      },
+      "BudgetUsage": {
+        "additionalProperties": false,
+        "description": "Actual usage derived only from accepted Run Events.",
+        "properties": {
+          "model_iterations": {
+            "default": 0,
+            "maximum": 100000,
+            "minimum": 0,
+            "title": "Model Iterations",
+            "type": "integer"
+          },
+          "input_tokens": {
+            "default": 0,
+            "maximum": 20000000000,
+            "minimum": 0,
+            "title": "Input Tokens",
+            "type": "integer"
+          },
+          "output_tokens": {
+            "default": 0,
+            "maximum": 20000000000,
+            "minimum": 0,
+            "title": "Output Tokens",
+            "type": "integer"
+          },
+          "cost_microusd": {
+            "default": 0,
+            "maximum": 20001000000000000,
+            "minimum": 0,
+            "title": "Cost Microusd",
+            "type": "integer"
+          },
+          "tool_calls": {
+            "default": 0,
+            "maximum": 1000000,
+            "minimum": 0,
+            "title": "Tool Calls",
+            "type": "integer"
+          }
+        },
+        "title": "BudgetUsage",
+        "type": "object"
+      },
+      "ErrorCategory": {
+        "description": "Stable high-level class used for handling and aggregation.",
+        "enum": [
+          "validation",
+          "budget",
+          "provider",
+          "tool",
+          "persistence",
+          "internal"
+        ],
+        "title": "ErrorCategory",
+        "type": "string"
+      },
+      "ErrorCode": {
+        "description": "Initial stable error codes; later Features may add specific codes.",
+        "enum": [
+          "invalid_input",
+          "invalid_event",
+          "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
+          "budget_exhausted",
+          "provider_error",
+          "provider_timeout",
+          "provider_rate_limited",
+          "provider_unavailable",
+          "provider_authentication",
+          "provider_permission_denied",
+          "provider_invalid_request",
+          "provider_refused",
+          "provider_protocol_error",
+          "tool_not_found",
+          "tool_invalid_input",
+          "tool_permission_denied",
+          "tool_timeout",
+          "tool_output_too_large",
+          "tool_error",
+          "workspace_path_denied",
+          "workspace_not_found",
+          "workspace_wrong_type",
+          "workspace_not_text",
+          "workspace_limit_exceeded",
+          "workspace_access_failed",
+          "persistence_error",
+          "internal_error"
+        ],
+        "title": "ErrorCode",
+        "type": "string"
+      },
+      "ErrorInfo": {
+        "additionalProperties": false,
+        "description": "Serializable error data that is safe to expose and persist.",
+        "properties": {
+          "category": {
+            "$ref": "#/$defs/ErrorCategory"
+          },
+          "code": {
+            "$ref": "#/$defs/ErrorCode"
+          },
+          "message": {
+            "maxLength": 1000,
+            "minLength": 1,
+            "title": "Message",
+            "type": "string"
+          },
+          "retryable": {
+            "default": false,
+            "title": "Retryable",
+            "type": "boolean"
+          },
+          "details": {
+            "additionalProperties": {
+              "$ref": "#/$defs/SafeDetailValue"
+            },
+            "maxProperties": 32,
+            "title": "Details",
+            "type": "object"
+          }
+        },
+        "required": [
+          "category",
+          "code",
+          "message"
+        ],
+        "title": "ErrorInfo",
+        "type": "object"
+      },
+      "ModelCallId": {
+        "description": "Identify one model call independently of provider request IDs.",
+        "format": "uuid4",
+        "title": "ModelCallId",
+        "type": "string"
+      },
+      "RunId": {
+        "description": "Identify one user-request execution.",
+        "format": "uuid4",
+        "title": "RunId",
+        "type": "string"
+      },
+      "RunInspection": {
+        "additionalProperties": false,
+        "description": "One trusted Run projection plus outputs recovered from committed Events.",
+        "properties": {
+          "run_id": {
+            "$ref": "#/$defs/RunId"
+          },
+          "state": {
+            "$ref": "#/$defs/RunState"
+          },
+          "artifacts": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/Artifact"
+            },
+            "title": "Artifacts",
+            "type": "array"
+          }
+        },
+        "required": [
+          "run_id",
+          "state"
+        ],
+        "title": "RunInspection",
+        "type": "object"
+      },
+      "RunState": {
+        "additionalProperties": false,
+        "description": "Immutable Run projection produced by the pure reducer.",
+        "properties": {
+          "run_id": {
+            "$ref": "#/$defs/RunId"
+          },
+          "session_id": {
+            "$ref": "#/$defs/SessionId"
+          },
+          "status": {
+            "$ref": "#/$defs/RunStatus"
+          },
+          "budget_limits": {
+            "$ref": "#/$defs/BudgetLimits"
+          },
+          "budget_usage": {
+            "$ref": "#/$defs/BudgetUsage"
+          },
+          "activities": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ActivityState"
+            },
+            "title": "Activities",
+            "type": "array"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Started At"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Completed At"
+          },
+          "terminal_error": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ErrorInfo"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "last_sequence": {
+            "minimum": 1,
+            "title": "Last Sequence",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "run_id",
+          "session_id",
+          "status",
+          "budget_limits",
+          "created_at",
+          "last_sequence"
+        ],
+        "title": "RunState",
+        "type": "object"
+      },
+      "RunStatus": {
+        "description": "P1-visible lifecycle states for one Run.",
+        "enum": [
+          "queued",
+          "running",
+          "succeeded",
+          "failed"
+        ],
+        "title": "RunStatus",
+        "type": "string"
+      },
+      "SafeDetailValue": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "SessionId": {
+        "description": "Identify a conversation container.",
+        "format": "uuid4",
+        "title": "SessionId",
+        "type": "string"
+      },
+      "ToolCallId": {
+        "description": "Correlate one tool request with its result.",
+        "format": "uuid4",
+        "title": "ToolCallId",
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Result of ``bearagent run inspect RUN_ID``.",
+    "properties": {
+      "schema_version": {
+        "const": 1,
+        "default": 1,
+        "title": "Schema Version",
+        "type": "integer"
+      },
+      "command": {
+        "const": "inspect",
+        "default": "inspect",
+        "title": "Command",
+        "type": "string"
+      },
+      "result": {
+        "$ref": "#/$defs/RunInspection"
+      }
+    },
+    "required": [
+      "result"
+    ],
+    "title": "InspectCommandOutput",
+    "type": "object"
+  },
+  "RunCommandOutput": {
+    "$defs": {
+      "ActivityId": {
+        "description": "Identify one model or tool operation.",
+        "format": "uuid4",
+        "title": "ActivityId",
+        "type": "string"
+      },
+      "ActivityKind": {
+        "description": "Kinds of serial operations tracked by the P1 reducer.",
+        "enum": [
+          "model",
+          "tool"
+        ],
+        "title": "ActivityKind",
+        "type": "string"
+      },
+      "ActivityState": {
+        "additionalProperties": false,
+        "description": "Immutable state for one model or Tool operation.",
+        "properties": {
+          "activity_id": {
+            "$ref": "#/$defs/ActivityId"
+          },
+          "kind": {
+            "$ref": "#/$defs/ActivityKind"
+          },
+          "status": {
+            "$ref": "#/$defs/ActivityStatus"
+          },
+          "requested_at": {
+            "format": "date-time",
+            "title": "Requested At",
+            "type": "string"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Started At"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Completed At"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ErrorInfo"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "model_call_id": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ModelCallId"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "tool_call_id": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ToolCallId"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "tool_name": {
+            "anyOf": [
+              {
+                "pattern": "^[A-Za-z][A-Za-z0-9_.-]{0,127}$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Tool Name"
+          }
+        },
+        "required": [
+          "activity_id",
+          "kind",
+          "status",
+          "requested_at"
+        ],
+        "title": "ActivityState",
+        "type": "object"
+      },
+      "ActivityStatus": {
+        "description": "P1 Activity lifecycle states.",
+        "enum": [
+          "pending",
+          "running",
+          "succeeded",
+          "failed"
+        ],
+        "title": "ActivityStatus",
+        "type": "string"
+      },
+      "Artifact": {
+        "additionalProperties": false,
+        "description": "Bounded metadata for one retrievable output, without access authority.",
+        "properties": {
+          "artifact_id": {
+            "$ref": "#/$defs/ArtifactId"
+          },
+          "path": {
+            "maxLength": 4096,
+            "minLength": 1,
+            "title": "Path",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/$defs/ArtifactKind"
+          },
+          "encoding": {
+            "$ref": "#/$defs/ArtifactEncoding"
+          },
+          "size_bytes": {
+            "minimum": 0,
+            "title": "Size Bytes",
+            "type": "integer"
+          },
+          "sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Sha256",
+            "type": "string"
+          }
+        },
+        "required": [
+          "artifact_id",
+          "path",
+          "kind",
+          "encoding",
+          "size_bytes",
+          "sha256"
+        ],
+        "title": "Artifact",
+        "type": "object"
+      },
+      "ArtifactEncoding": {
+        "description": "Encoding used by a text Artifact.",
+        "enum": [
+          "utf-8"
+        ],
+        "title": "ArtifactEncoding",
+        "type": "string"
+      },
+      "ArtifactId": {
+        "description": "Identify one retrievable Run output.",
+        "format": "uuid4",
+        "title": "ArtifactId",
+        "type": "string"
+      },
+      "ArtifactKind": {
+        "description": "Stable high-level representation of one Artifact.",
+        "enum": [
+          "text"
+        ],
+        "title": "ArtifactKind",
+        "type": "string"
+      },
+      "BudgetLimits": {
+        "additionalProperties": false,
+        "description": "Finite limits selected by a trusted Run creation boundary.",
+        "properties": {
+          "max_model_iterations": {
+            "maximum": 100000,
+            "minimum": 0,
+            "title": "Max Model Iterations",
+            "type": "integer"
+          },
+          "max_tokens": {
+            "maximum": 10000000000,
+            "minimum": 0,
+            "title": "Max Tokens",
+            "type": "integer"
+          },
+          "max_cost_microusd": {
+            "maximum": 1000000000000,
+            "minimum": 0,
+            "title": "Max Cost Microusd",
+            "type": "integer"
+          },
+          "max_wall_time_ms": {
+            "maximum": 2678400000,
+            "minimum": 0,
+            "title": "Max Wall Time Ms",
+            "type": "integer"
+          },
+          "max_tool_calls": {
+            "maximum": 1000000,
+            "minimum": 0,
+            "title": "Max Tool Calls",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "max_model_iterations",
+          "max_tokens",
+          "max_cost_microusd",
+          "max_wall_time_ms",
+          "max_tool_calls"
+        ],
+        "title": "BudgetLimits",
+        "type": "object"
+      },
+      "BudgetUsage": {
+        "additionalProperties": false,
+        "description": "Actual usage derived only from accepted Run Events.",
+        "properties": {
+          "model_iterations": {
+            "default": 0,
+            "maximum": 100000,
+            "minimum": 0,
+            "title": "Model Iterations",
+            "type": "integer"
+          },
+          "input_tokens": {
+            "default": 0,
+            "maximum": 20000000000,
+            "minimum": 0,
+            "title": "Input Tokens",
+            "type": "integer"
+          },
+          "output_tokens": {
+            "default": 0,
+            "maximum": 20000000000,
+            "minimum": 0,
+            "title": "Output Tokens",
+            "type": "integer"
+          },
+          "cost_microusd": {
+            "default": 0,
+            "maximum": 20001000000000000,
+            "minimum": 0,
+            "title": "Cost Microusd",
+            "type": "integer"
+          },
+          "tool_calls": {
+            "default": 0,
+            "maximum": 1000000,
+            "minimum": 0,
+            "title": "Tool Calls",
+            "type": "integer"
+          }
+        },
+        "title": "BudgetUsage",
+        "type": "object"
+      },
+      "ErrorCategory": {
+        "description": "Stable high-level class used for handling and aggregation.",
+        "enum": [
+          "validation",
+          "budget",
+          "provider",
+          "tool",
+          "persistence",
+          "internal"
+        ],
+        "title": "ErrorCategory",
+        "type": "string"
+      },
+      "ErrorCode": {
+        "description": "Initial stable error codes; later Features may add specific codes.",
+        "enum": [
+          "invalid_input",
+          "invalid_event",
+          "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
+          "budget_exhausted",
+          "provider_error",
+          "provider_timeout",
+          "provider_rate_limited",
+          "provider_unavailable",
+          "provider_authentication",
+          "provider_permission_denied",
+          "provider_invalid_request",
+          "provider_refused",
+          "provider_protocol_error",
+          "tool_not_found",
+          "tool_invalid_input",
+          "tool_permission_denied",
+          "tool_timeout",
+          "tool_output_too_large",
+          "tool_error",
+          "workspace_path_denied",
+          "workspace_not_found",
+          "workspace_wrong_type",
+          "workspace_not_text",
+          "workspace_limit_exceeded",
+          "workspace_access_failed",
+          "persistence_error",
+          "internal_error"
+        ],
+        "title": "ErrorCode",
+        "type": "string"
+      },
+      "ErrorInfo": {
+        "additionalProperties": false,
+        "description": "Serializable error data that is safe to expose and persist.",
+        "properties": {
+          "category": {
+            "$ref": "#/$defs/ErrorCategory"
+          },
+          "code": {
+            "$ref": "#/$defs/ErrorCode"
+          },
+          "message": {
+            "maxLength": 1000,
+            "minLength": 1,
+            "title": "Message",
+            "type": "string"
+          },
+          "retryable": {
+            "default": false,
+            "title": "Retryable",
+            "type": "boolean"
+          },
+          "details": {
+            "additionalProperties": {
+              "$ref": "#/$defs/SafeDetailValue"
+            },
+            "maxProperties": 32,
+            "title": "Details",
+            "type": "object"
+          }
+        },
+        "required": [
+          "category",
+          "code",
+          "message"
+        ],
+        "title": "ErrorInfo",
+        "type": "object"
+      },
+      "ModelCallId": {
+        "description": "Identify one model call independently of provider request IDs.",
+        "format": "uuid4",
+        "title": "ModelCallId",
+        "type": "string"
+      },
+      "RunId": {
+        "description": "Identify one user-request execution.",
+        "format": "uuid4",
+        "title": "RunId",
+        "type": "string"
+      },
+      "RunResult": {
+        "additionalProperties": false,
+        "description": "Terminal application result without adapter-specific state.",
+        "properties": {
+          "run_id": {
+            "$ref": "#/$defs/RunId"
+          },
+          "state": {
+            "$ref": "#/$defs/RunState"
+          },
+          "final_text": {
+            "anyOf": [
+              {
+                "maxLength": 4000000,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Final Text"
+          },
+          "artifacts": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/Artifact"
+            },
+            "title": "Artifacts",
+            "type": "array"
+          }
+        },
+        "required": [
+          "run_id",
+          "state"
+        ],
+        "title": "RunResult",
+        "type": "object"
+      },
+      "RunState": {
+        "additionalProperties": false,
+        "description": "Immutable Run projection produced by the pure reducer.",
+        "properties": {
+          "run_id": {
+            "$ref": "#/$defs/RunId"
+          },
+          "session_id": {
+            "$ref": "#/$defs/SessionId"
+          },
+          "status": {
+            "$ref": "#/$defs/RunStatus"
+          },
+          "budget_limits": {
+            "$ref": "#/$defs/BudgetLimits"
+          },
+          "budget_usage": {
+            "$ref": "#/$defs/BudgetUsage"
+          },
+          "activities": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ActivityState"
+            },
+            "title": "Activities",
+            "type": "array"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Started At"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Completed At"
+          },
+          "terminal_error": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ErrorInfo"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "last_sequence": {
+            "minimum": 1,
+            "title": "Last Sequence",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "run_id",
+          "session_id",
+          "status",
+          "budget_limits",
+          "created_at",
+          "last_sequence"
+        ],
+        "title": "RunState",
+        "type": "object"
+      },
+      "RunStatus": {
+        "description": "P1-visible lifecycle states for one Run.",
+        "enum": [
+          "queued",
+          "running",
+          "succeeded",
+          "failed"
+        ],
+        "title": "RunStatus",
+        "type": "string"
+      },
+      "SafeDetailValue": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "SessionId": {
+        "description": "Identify a conversation container.",
+        "format": "uuid4",
+        "title": "SessionId",
+        "type": "string"
+      },
+      "ToolCallId": {
+        "description": "Correlate one tool request with its result.",
+        "format": "uuid4",
+        "title": "ToolCallId",
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Successful or terminal result of ``bearagent run OBJECTIVE``.",
+    "properties": {
+      "schema_version": {
+        "const": 1,
+        "default": 1,
+        "title": "Schema Version",
+        "type": "integer"
+      },
+      "command": {
+        "const": "run",
+        "default": "run",
+        "title": "Command",
+        "type": "string"
+      },
+      "result": {
+        "$ref": "#/$defs/RunResult"
+      }
+    },
+    "required": [
+      "result"
+    ],
+    "title": "RunCommandOutput",
+    "type": "object"
+  }
+}

--- a/tests/contract/snapshots/domain_schemas.json
+++ b/tests/contract/snapshots/domain_schemas.json
@@ -52,6 +52,8 @@
           "invalid_input",
           "invalid_event",
           "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
           "budget_exhausted",
           "provider_error",
           "provider_timeout",
@@ -964,6 +966,8 @@
           "invalid_input",
           "invalid_event",
           "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
           "budget_exhausted",
           "provider_error",
           "provider_timeout",
@@ -1138,6 +1142,138 @@
     "format": "uuid4",
     "title": "EventId",
     "type": "string"
+  },
+  "EventPage": {
+    "$defs": {
+      "CausationId": {
+        "description": "Identify the command, Activity, or Event that caused a fact.",
+        "format": "uuid4",
+        "title": "CausationId",
+        "type": "string"
+      },
+      "CorrelationId": {
+        "description": "Correlate facts that belong to one diagnostic flow.",
+        "format": "uuid4",
+        "title": "CorrelationId",
+        "type": "string"
+      },
+      "Event": {
+        "additionalProperties": false,
+        "description": "Common envelope for an immutable domain fact.",
+        "properties": {
+          "event_id": {
+            "$ref": "#/$defs/EventId"
+          },
+          "run_id": {
+            "$ref": "#/$defs/RunId"
+          },
+          "sequence": {
+            "minimum": 1,
+            "title": "Sequence",
+            "type": "integer"
+          },
+          "event_type": {
+            "pattern": "^[A-Z][A-Za-z0-9]{0,127}$",
+            "title": "Event Type",
+            "type": "string"
+          },
+          "schema_version": {
+            "default": 1,
+            "minimum": 1,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "occurred_at": {
+            "format": "date-time",
+            "title": "Occurred At",
+            "type": "string"
+          },
+          "causation_id": {
+            "$ref": "#/$defs/CausationId"
+          },
+          "correlation_id": {
+            "$ref": "#/$defs/CorrelationId"
+          },
+          "payload": {
+            "additionalProperties": {
+              "$ref": "#/$defs/JsonValue"
+            },
+            "title": "Payload",
+            "type": "object"
+          }
+        },
+        "required": [
+          "event_id",
+          "run_id",
+          "sequence",
+          "event_type",
+          "occurred_at",
+          "causation_id",
+          "correlation_id"
+        ],
+        "title": "Event",
+        "type": "object"
+      },
+      "EventId": {
+        "description": "Identify one immutable persisted fact.",
+        "format": "uuid4",
+        "title": "EventId",
+        "type": "string"
+      },
+      "JsonValue": {},
+      "RunId": {
+        "description": "Identify one user-request execution.",
+        "format": "uuid4",
+        "title": "RunId",
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "description": "A bounded, contiguous page of committed Events for one Run.",
+    "properties": {
+      "run_id": {
+        "$ref": "#/$defs/RunId"
+      },
+      "after_sequence": {
+        "maximum": 9223372036854775807,
+        "minimum": 0,
+        "title": "After Sequence",
+        "type": "integer"
+      },
+      "limit": {
+        "maximum": 10000,
+        "minimum": 1,
+        "title": "Limit",
+        "type": "integer"
+      },
+      "events": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Event"
+        },
+        "title": "Events",
+        "type": "array"
+      },
+      "next_after_sequence": {
+        "maximum": 9223372036854775807,
+        "minimum": 0,
+        "title": "Next After Sequence",
+        "type": "integer"
+      },
+      "has_more": {
+        "title": "Has More",
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "run_id",
+      "after_sequence",
+      "limit",
+      "next_after_sequence",
+      "has_more"
+    ],
+    "title": "EventPage",
+    "type": "object"
   },
   "Message": {
     "$defs": {
@@ -1620,6 +1756,8 @@
           "invalid_input",
           "invalid_event",
           "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
           "budget_exhausted",
           "provider_error",
           "provider_timeout",
@@ -1778,6 +1916,8 @@
           "invalid_input",
           "invalid_event",
           "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
           "budget_exhausted",
           "provider_error",
           "provider_timeout",
@@ -3201,6 +3341,8 @@
           "invalid_input",
           "invalid_event",
           "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
           "budget_exhausted",
           "provider_error",
           "provider_timeout",
@@ -3321,6 +3463,8 @@
           "invalid_input",
           "invalid_event",
           "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
           "budget_exhausted",
           "provider_error",
           "provider_timeout",
@@ -3626,6 +3770,727 @@
     "title": "RunInput",
     "type": "object"
   },
+  "RunInspection": {
+    "$defs": {
+      "ActivityId": {
+        "description": "Identify one model or tool operation.",
+        "format": "uuid4",
+        "title": "ActivityId",
+        "type": "string"
+      },
+      "ActivityKind": {
+        "description": "Kinds of serial operations tracked by the P1 reducer.",
+        "enum": [
+          "model",
+          "tool"
+        ],
+        "title": "ActivityKind",
+        "type": "string"
+      },
+      "ActivityState": {
+        "additionalProperties": false,
+        "description": "Immutable state for one model or Tool operation.",
+        "properties": {
+          "activity_id": {
+            "$ref": "#/$defs/ActivityId"
+          },
+          "kind": {
+            "$ref": "#/$defs/ActivityKind"
+          },
+          "status": {
+            "$ref": "#/$defs/ActivityStatus"
+          },
+          "requested_at": {
+            "format": "date-time",
+            "title": "Requested At",
+            "type": "string"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Started At"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Completed At"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ErrorInfo"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "model_call_id": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ModelCallId"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "tool_call_id": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ToolCallId"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "tool_name": {
+            "anyOf": [
+              {
+                "pattern": "^[A-Za-z][A-Za-z0-9_.-]{0,127}$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Tool Name"
+          }
+        },
+        "required": [
+          "activity_id",
+          "kind",
+          "status",
+          "requested_at"
+        ],
+        "title": "ActivityState",
+        "type": "object"
+      },
+      "ActivityStatus": {
+        "description": "P1 Activity lifecycle states.",
+        "enum": [
+          "pending",
+          "running",
+          "succeeded",
+          "failed"
+        ],
+        "title": "ActivityStatus",
+        "type": "string"
+      },
+      "Artifact": {
+        "additionalProperties": false,
+        "description": "Bounded metadata for one retrievable output, without access authority.",
+        "properties": {
+          "artifact_id": {
+            "$ref": "#/$defs/ArtifactId"
+          },
+          "path": {
+            "maxLength": 4096,
+            "minLength": 1,
+            "title": "Path",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/$defs/ArtifactKind"
+          },
+          "encoding": {
+            "$ref": "#/$defs/ArtifactEncoding"
+          },
+          "size_bytes": {
+            "minimum": 0,
+            "title": "Size Bytes",
+            "type": "integer"
+          },
+          "sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Sha256",
+            "type": "string"
+          }
+        },
+        "required": [
+          "artifact_id",
+          "path",
+          "kind",
+          "encoding",
+          "size_bytes",
+          "sha256"
+        ],
+        "title": "Artifact",
+        "type": "object"
+      },
+      "ArtifactEncoding": {
+        "description": "Encoding used by a text Artifact.",
+        "enum": [
+          "utf-8"
+        ],
+        "title": "ArtifactEncoding",
+        "type": "string"
+      },
+      "ArtifactId": {
+        "description": "Identify one retrievable Run output.",
+        "format": "uuid4",
+        "title": "ArtifactId",
+        "type": "string"
+      },
+      "ArtifactKind": {
+        "description": "Stable high-level representation of one Artifact.",
+        "enum": [
+          "text"
+        ],
+        "title": "ArtifactKind",
+        "type": "string"
+      },
+      "BudgetLimits": {
+        "additionalProperties": false,
+        "description": "Finite limits selected by a trusted Run creation boundary.",
+        "properties": {
+          "max_model_iterations": {
+            "maximum": 100000,
+            "minimum": 0,
+            "title": "Max Model Iterations",
+            "type": "integer"
+          },
+          "max_tokens": {
+            "maximum": 10000000000,
+            "minimum": 0,
+            "title": "Max Tokens",
+            "type": "integer"
+          },
+          "max_cost_microusd": {
+            "maximum": 1000000000000,
+            "minimum": 0,
+            "title": "Max Cost Microusd",
+            "type": "integer"
+          },
+          "max_wall_time_ms": {
+            "maximum": 2678400000,
+            "minimum": 0,
+            "title": "Max Wall Time Ms",
+            "type": "integer"
+          },
+          "max_tool_calls": {
+            "maximum": 1000000,
+            "minimum": 0,
+            "title": "Max Tool Calls",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "max_model_iterations",
+          "max_tokens",
+          "max_cost_microusd",
+          "max_wall_time_ms",
+          "max_tool_calls"
+        ],
+        "title": "BudgetLimits",
+        "type": "object"
+      },
+      "BudgetUsage": {
+        "additionalProperties": false,
+        "description": "Actual usage derived only from accepted Run Events.",
+        "properties": {
+          "model_iterations": {
+            "default": 0,
+            "maximum": 100000,
+            "minimum": 0,
+            "title": "Model Iterations",
+            "type": "integer"
+          },
+          "input_tokens": {
+            "default": 0,
+            "maximum": 20000000000,
+            "minimum": 0,
+            "title": "Input Tokens",
+            "type": "integer"
+          },
+          "output_tokens": {
+            "default": 0,
+            "maximum": 20000000000,
+            "minimum": 0,
+            "title": "Output Tokens",
+            "type": "integer"
+          },
+          "cost_microusd": {
+            "default": 0,
+            "maximum": 20001000000000000,
+            "minimum": 0,
+            "title": "Cost Microusd",
+            "type": "integer"
+          },
+          "tool_calls": {
+            "default": 0,
+            "maximum": 1000000,
+            "minimum": 0,
+            "title": "Tool Calls",
+            "type": "integer"
+          }
+        },
+        "title": "BudgetUsage",
+        "type": "object"
+      },
+      "ErrorCategory": {
+        "description": "Stable high-level class used for handling and aggregation.",
+        "enum": [
+          "validation",
+          "budget",
+          "provider",
+          "tool",
+          "persistence",
+          "internal"
+        ],
+        "title": "ErrorCategory",
+        "type": "string"
+      },
+      "ErrorCode": {
+        "description": "Initial stable error codes; later Features may add specific codes.",
+        "enum": [
+          "invalid_input",
+          "invalid_event",
+          "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
+          "budget_exhausted",
+          "provider_error",
+          "provider_timeout",
+          "provider_rate_limited",
+          "provider_unavailable",
+          "provider_authentication",
+          "provider_permission_denied",
+          "provider_invalid_request",
+          "provider_refused",
+          "provider_protocol_error",
+          "tool_not_found",
+          "tool_invalid_input",
+          "tool_permission_denied",
+          "tool_timeout",
+          "tool_output_too_large",
+          "tool_error",
+          "workspace_path_denied",
+          "workspace_not_found",
+          "workspace_wrong_type",
+          "workspace_not_text",
+          "workspace_limit_exceeded",
+          "workspace_access_failed",
+          "persistence_error",
+          "internal_error"
+        ],
+        "title": "ErrorCode",
+        "type": "string"
+      },
+      "ErrorInfo": {
+        "additionalProperties": false,
+        "description": "Serializable error data that is safe to expose and persist.",
+        "properties": {
+          "category": {
+            "$ref": "#/$defs/ErrorCategory"
+          },
+          "code": {
+            "$ref": "#/$defs/ErrorCode"
+          },
+          "message": {
+            "maxLength": 1000,
+            "minLength": 1,
+            "title": "Message",
+            "type": "string"
+          },
+          "retryable": {
+            "default": false,
+            "title": "Retryable",
+            "type": "boolean"
+          },
+          "details": {
+            "additionalProperties": {
+              "$ref": "#/$defs/SafeDetailValue"
+            },
+            "maxProperties": 32,
+            "title": "Details",
+            "type": "object"
+          }
+        },
+        "required": [
+          "category",
+          "code",
+          "message"
+        ],
+        "title": "ErrorInfo",
+        "type": "object"
+      },
+      "ModelCallId": {
+        "description": "Identify one model call independently of provider request IDs.",
+        "format": "uuid4",
+        "title": "ModelCallId",
+        "type": "string"
+      },
+      "RunId": {
+        "description": "Identify one user-request execution.",
+        "format": "uuid4",
+        "title": "RunId",
+        "type": "string"
+      },
+      "RunState": {
+        "additionalProperties": false,
+        "description": "Immutable Run projection produced by the pure reducer.",
+        "properties": {
+          "run_id": {
+            "$ref": "#/$defs/RunId"
+          },
+          "session_id": {
+            "$ref": "#/$defs/SessionId"
+          },
+          "status": {
+            "$ref": "#/$defs/RunStatus"
+          },
+          "budget_limits": {
+            "$ref": "#/$defs/BudgetLimits"
+          },
+          "budget_usage": {
+            "$ref": "#/$defs/BudgetUsage"
+          },
+          "activities": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ActivityState"
+            },
+            "title": "Activities",
+            "type": "array"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Started At"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Completed At"
+          },
+          "terminal_error": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ErrorInfo"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "last_sequence": {
+            "minimum": 1,
+            "title": "Last Sequence",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "run_id",
+          "session_id",
+          "status",
+          "budget_limits",
+          "created_at",
+          "last_sequence"
+        ],
+        "title": "RunState",
+        "type": "object"
+      },
+      "RunStatus": {
+        "description": "P1-visible lifecycle states for one Run.",
+        "enum": [
+          "queued",
+          "running",
+          "succeeded",
+          "failed"
+        ],
+        "title": "RunStatus",
+        "type": "string"
+      },
+      "SafeDetailValue": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "SessionId": {
+        "description": "Identify a conversation container.",
+        "format": "uuid4",
+        "title": "SessionId",
+        "type": "string"
+      },
+      "ToolCallId": {
+        "description": "Correlate one tool request with its result.",
+        "format": "uuid4",
+        "title": "ToolCallId",
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "description": "One trusted Run projection plus outputs recovered from committed Events.",
+    "properties": {
+      "run_id": {
+        "$ref": "#/$defs/RunId"
+      },
+      "state": {
+        "$ref": "#/$defs/RunState"
+      },
+      "artifacts": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Artifact"
+        },
+        "title": "Artifacts",
+        "type": "array"
+      }
+    },
+    "required": [
+      "run_id",
+      "state"
+    ],
+    "title": "RunInspection",
+    "type": "object"
+  },
+  "RunProfile": {
+    "$defs": {
+      "AgentConfig": {
+        "additionalProperties": false,
+        "description": "Trusted, non-secret configuration snapshot for one Agent version.",
+        "properties": {
+          "agent_id": {
+            "pattern": "^[A-Za-z][A-Za-z0-9._-]{0,127}$",
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "agent_version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$",
+            "title": "Agent Version",
+            "type": "string"
+          },
+          "instructions": {
+            "maxLength": 65536,
+            "minLength": 1,
+            "title": "Instructions",
+            "type": "string"
+          },
+          "model": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$",
+            "title": "Model",
+            "type": "string"
+          },
+          "prompt_version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$",
+            "title": "Prompt Version",
+            "type": "string"
+          },
+          "context_version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$",
+            "title": "Context Version",
+            "type": "string"
+          },
+          "max_output_tokens": {
+            "exclusiveMinimum": 0,
+            "maximum": 10000000000,
+            "title": "Max Output Tokens",
+            "type": "integer"
+          },
+          "model_timeout_ms": {
+            "exclusiveMinimum": 0,
+            "maximum": 600000,
+            "title": "Model Timeout Ms",
+            "type": "integer"
+          },
+          "max_context_chars": {
+            "exclusiveMinimum": 0,
+            "maximum": 4000000,
+            "title": "Max Context Chars",
+            "type": "integer"
+          },
+          "max_tool_result_bytes": {
+            "maximum": 4000000,
+            "minimum": 128,
+            "title": "Max Tool Result Bytes",
+            "type": "integer"
+          },
+          "tool_names": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 128,
+            "title": "Tool Names",
+            "type": "array"
+          },
+          "pricing": {
+            "$ref": "#/$defs/ModelPricing"
+          }
+        },
+        "required": [
+          "agent_id",
+          "agent_version",
+          "instructions",
+          "model",
+          "prompt_version",
+          "context_version",
+          "max_output_tokens",
+          "model_timeout_ms",
+          "max_context_chars",
+          "max_tool_result_bytes",
+          "pricing"
+        ],
+        "title": "AgentConfig",
+        "type": "object"
+      },
+      "BudgetLimits": {
+        "additionalProperties": false,
+        "description": "Finite limits selected by a trusted Run creation boundary.",
+        "properties": {
+          "max_model_iterations": {
+            "maximum": 100000,
+            "minimum": 0,
+            "title": "Max Model Iterations",
+            "type": "integer"
+          },
+          "max_tokens": {
+            "maximum": 10000000000,
+            "minimum": 0,
+            "title": "Max Tokens",
+            "type": "integer"
+          },
+          "max_cost_microusd": {
+            "maximum": 1000000000000,
+            "minimum": 0,
+            "title": "Max Cost Microusd",
+            "type": "integer"
+          },
+          "max_wall_time_ms": {
+            "maximum": 2678400000,
+            "minimum": 0,
+            "title": "Max Wall Time Ms",
+            "type": "integer"
+          },
+          "max_tool_calls": {
+            "maximum": 1000000,
+            "minimum": 0,
+            "title": "Max Tool Calls",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "max_model_iterations",
+          "max_tokens",
+          "max_cost_microusd",
+          "max_wall_time_ms",
+          "max_tool_calls"
+        ],
+        "title": "BudgetLimits",
+        "type": "object"
+      },
+      "ModelPricing": {
+        "additionalProperties": false,
+        "description": "Versioned integer rates used for deterministic local cost estimates.",
+        "properties": {
+          "version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$",
+            "title": "Version",
+            "type": "string"
+          },
+          "input_microusd_per_million_tokens": {
+            "maximum": 1000000000000,
+            "minimum": 0,
+            "title": "Input Microusd Per Million Tokens",
+            "type": "integer"
+          },
+          "output_microusd_per_million_tokens": {
+            "maximum": 1000000000000,
+            "minimum": 0,
+            "title": "Output Microusd Per Million Tokens",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "version",
+          "input_microusd_per_million_tokens",
+          "output_microusd_per_million_tokens"
+        ],
+        "title": "ModelPricing",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Versioned, non-secret configuration loaded by a trusted interface.",
+    "properties": {
+      "schema_version": {
+        "const": 1,
+        "default": 1,
+        "title": "Schema Version",
+        "type": "integer"
+      },
+      "agent_config": {
+        "$ref": "#/$defs/AgentConfig"
+      },
+      "budget_limits": {
+        "$ref": "#/$defs/BudgetLimits"
+      }
+    },
+    "required": [
+      "agent_config",
+      "budget_limits"
+    ],
+    "title": "RunProfile",
+    "type": "object"
+  },
   "RunResult": {
     "$defs": {
       "ActivityId": {
@@ -3924,6 +4789,8 @@
           "invalid_input",
           "invalid_event",
           "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
           "budget_exhausted",
           "provider_error",
           "provider_timeout",
@@ -4419,6 +5286,8 @@
           "invalid_input",
           "invalid_event",
           "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
           "budget_exhausted",
           "provider_error",
           "provider_timeout",
@@ -4704,6 +5573,8 @@
           "invalid_input",
           "invalid_event",
           "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
           "budget_exhausted",
           "provider_error",
           "provider_timeout",
@@ -5031,6 +5902,8 @@
           "invalid_input",
           "invalid_event",
           "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
           "budget_exhausted",
           "provider_error",
           "provider_timeout",
@@ -5171,6 +6044,8 @@
           "invalid_input",
           "invalid_event",
           "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
           "budget_exhausted",
           "provider_error",
           "provider_timeout",
@@ -5674,6 +6549,8 @@
           "invalid_input",
           "invalid_event",
           "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
           "budget_exhausted",
           "provider_error",
           "provider_timeout",
@@ -6009,6 +6886,8 @@
           "invalid_input",
           "invalid_event",
           "invalid_state_transition",
+          "run_not_found",
+          "query_limit_exceeded",
           "budget_exhausted",
           "provider_error",
           "provider_timeout",

--- a/tests/contract/test_cli_schemas.py
+++ b/tests/contract/test_cli_schemas.py
@@ -1,0 +1,12 @@
+import json
+from pathlib import Path
+
+from bearagent.interfaces.cli.contracts import public_cli_schemas
+
+SNAPSHOT_PATH = Path(__file__).parent / "snapshots" / "cli_schemas.json"
+
+
+def test_public_cli_schemas_match_compatibility_snapshot() -> None:
+    expected = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+
+    assert public_cli_schemas() == expected

--- a/tests/evals/test_p1_agent_loop_tasks.py
+++ b/tests/evals/test_p1_agent_loop_tasks.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import json
 import shutil
 from pathlib import Path
 from typing import Literal
@@ -12,7 +13,8 @@ from bearagent.adapters.sqlite import SqliteEventStore
 from bearagent.adapters.testing import InMemoryEventStore, ScriptedFakeModelProvider
 from bearagent.adapters.tools import build_workspace_tools
 from bearagent.application.agent_loop import AgentLoop
-from bearagent.domain.agent import AgentConfig, ModelPricing, RunInput, RunResult
+from bearagent.bootstrap import build_run_query_service, build_run_services
+from bearagent.domain.agent import AgentConfig, ModelPricing, RunInput, RunProfile, RunResult
 from bearagent.domain.events import Event
 from bearagent.domain.ids import SessionId, ToolCallId
 from bearagent.domain.model import (
@@ -282,4 +284,73 @@ def test_p1_fixed_task_suite_reaches_5_of_5_on_both_stores(
         assert result.artifacts == ()
         assert "ToolCallFailed" in tuple(event.event_type for event in events)
 
+    assert len(provider.requests) == len(script_for(task))
+
+
+@pytest.mark.parametrize("task", TASKS, ids=lambda task: f"production-{task.task_id}")
+def test_p1_fixed_task_suite_reaches_5_of_5_through_production_composition(
+    task: EvalTask,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    shutil.copytree(EVAL_ROOT / "workspaces" / task.workspace_fixture, workspace)
+    registry = ToolRegistry(build_workspace_tools(workspace))
+    profile = RunProfile(
+        agent_config=config_for(registry, task),
+        budget_limits=BudgetLimits.model_validate(task.budget.model_dump()),
+    )
+    profile_path = tmp_path / "profile.json"
+    profile_path.write_text(
+        json.dumps(profile.model_dump(mode="json")),
+        encoding="utf-8",
+    )
+    database_path = tmp_path / "state.sqlite3"
+    provider = ScriptedFakeModelProvider(script_for(task))
+
+    async def exercise() -> tuple[RunResult, tuple[Event, ...]]:
+        services = await build_run_services(
+            profile_path=profile_path,
+            workspace_path=workspace,
+            database_path=database_path,
+            model_provider=provider,
+        )
+        result = await services.agent_loop.run(
+            RunInput(
+                session_id=SessionId.new(),
+                objective=task.objective,
+                budget_limits=services.profile.budget_limits,
+                agent_config=services.profile.agent_config,
+            )
+        )
+        reopened_queries = await build_run_query_service(database_path)
+        inspection = await reopened_queries.inspect(result.run_id)
+        page = await reopened_queries.events(result.run_id)
+        assert inspection.state == result.state
+        assert inspection.artifacts == result.artifacts
+        return result, page.events
+
+    result, events = asyncio.run(exercise())
+
+    assert tuple(event.event_type for event in events) == task.expected_event_types
+    requested_calls = tuple(
+        (payload.tool_name, dict(payload.request.arguments))
+        for event in events
+        if isinstance(payload := parse_run_event_payload(event), ToolCallRequestedPayloadV2)
+    )
+    assert requested_calls == tuple((call.name, call.arguments) for call in task.expected_calls)
+    if task.expected_terminal == "succeeded":
+        assert result.state.status is RunStatus.SUCCEEDED
+        assert task.output_content is not None
+        assert task.expected_artifact_path is not None
+        assert (workspace / task.expected_artifact_path).read_text(
+            encoding="utf-8"
+        ) == task.output_content
+        assert (
+            result.artifacts[-1].sha256
+            == hashlib.sha256(task.output_content.encode("utf-8")).hexdigest()
+        )
+    else:
+        assert result.state.status is RunStatus.FAILED
+        assert result.state.terminal_error is not None
+        assert result.state.terminal_error.code.value == "budget_exhausted"
     assert len(provider.requests) == len(script_for(task))

--- a/tests/integration/test_run_cli.py
+++ b/tests/integration/test_run_cli.py
@@ -1,0 +1,295 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+from tests.agent_loop_fixtures import agent_config, budget_limits
+from typer.testing import CliRunner
+
+import bearagent.interfaces.cli.main as cli_main
+from bearagent.adapters.testing import FakeModelProvider, ScriptedFakeModelProvider
+from bearagent.bootstrap import RunServices, build_run_services
+from bearagent.domain.agent import RunProfile
+from bearagent.domain.model import ModelCompleted, ModelFinishReason, ModelTextDelta, ModelUsage
+from bearagent.interfaces.cli.main import app
+from bearagent.ports.model import ModelProvider
+
+runner = CliRunner()
+
+
+def test_fake_provider_cli_run_then_inspect_and_page_events(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profile_path = tmp_path / "profile.json"
+    database_path = tmp_path / "data" / "bearagent.db"
+    profile = RunProfile(
+        agent_config=agent_config(),
+        budget_limits=budget_limits(),
+    )
+    profile_path.write_text(
+        json.dumps(profile.model_dump(mode="json")),
+        encoding="utf-8",
+    )
+    provider = ScriptedFakeModelProvider(
+        [
+            (
+                ModelTextDelta(text="The offline task is complete."),
+                ModelCompleted(
+                    provider_request_id="fake-response-1",
+                    model="test-model",
+                    finish_reason=ModelFinishReason.STOP,
+                    usage=ModelUsage(input_tokens=8, output_tokens=6),
+                ),
+            )
+        ]
+    )
+    _inject_provider(monkeypatch, provider)
+    objective = "private objective marker"
+
+    run = runner.invoke(
+        app,
+        [
+            "run",
+            "--json",
+            objective,
+            "--profile",
+            str(profile_path),
+            "--workspace",
+            str(tmp_path),
+            "--database",
+            str(database_path),
+        ],
+    )
+
+    assert run.exit_code == 0, run.output
+    run_payload = json.loads(run.stdout)
+    assert run_payload["schema_version"] == 1
+    assert run_payload["command"] == "run"
+    assert run_payload["result"]["final_text"] == "The offline task is complete."
+    run_id = run_payload["result"]["run_id"]
+    assert "Allocated Run ID:" in run.stderr
+
+    inspection = runner.invoke(
+        app,
+        ["run", "inspect", run_id, "--database", str(database_path), "--json"],
+    )
+    assert inspection.exit_code == 0, inspection.output
+    inspection_payload = json.loads(inspection.stdout)
+    assert inspection_payload["command"] == "inspect"
+    assert inspection_payload["result"]["state"] == run_payload["result"]["state"]
+
+    human_events = runner.invoke(
+        app,
+        ["run", "events", run_id, "--database", str(database_path), "--limit", "2"],
+    )
+    assert human_events.exit_code == 0, human_events.output
+    assert "has_more=true" in human_events.stdout
+    assert objective not in human_events.stdout
+
+    event_page = runner.invoke(
+        app,
+        [
+            "run",
+            "events",
+            run_id,
+            "--database",
+            str(database_path),
+            "--after-sequence",
+            "2",
+            "--limit",
+            "10",
+            "--json",
+        ],
+    )
+    assert event_page.exit_code == 0, event_page.output
+    event_payload = json.loads(event_page.stdout)
+    assert event_payload["command"] == "events"
+    assert event_payload["result"]["events"][0]["sequence"] == 3
+    assert event_payload["result"]["has_more"] is False
+
+
+def test_run_group_preserves_inspect_and_rejects_invalid_ids_as_safe_json(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "missing.db"
+
+    result = runner.invoke(
+        app,
+        ["run", "inspect", "not-a-uuid", "--database", str(database_path), "--json"],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["command"] == "inspect"
+    assert payload["error"]["code"] == "invalid_input"
+    assert not database_path.exists()
+
+
+def test_terminal_provider_failure_is_safe_json_and_exit_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profile_path = tmp_path / "profile.json"
+    profile = RunProfile(
+        agent_config=agent_config(),
+        budget_limits=budget_limits(),
+    )
+    profile_path.write_text(
+        json.dumps(profile.model_dump(mode="json")),
+        encoding="utf-8",
+    )
+    secret = "raw-provider-secret"
+    _inject_provider(monkeypatch, FakeModelProvider((), failure=RuntimeError(secret)))
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "must fail safely",
+            "--profile",
+            str(profile_path),
+            "--workspace",
+            str(tmp_path),
+            "--database",
+            str(tmp_path / "events.db"),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["result"]["state"]["status"] == "failed"
+    assert payload["result"]["state"]["terminal_error"]["code"] == "provider_error"
+    assert secret not in result.output
+
+
+def test_zero_model_budget_fails_as_a_durable_run_without_provider_credentials(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    profile_path = tmp_path / "profile.json"
+    profile = RunProfile(
+        agent_config=agent_config(),
+        budget_limits=budget_limits(max_model_iterations=0),
+    )
+    profile_path.write_text(
+        json.dumps(profile.model_dump(mode="json")),
+        encoding="utf-8",
+    )
+    database_path = tmp_path / "events.db"
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "must stop before a model call",
+            "--profile",
+            str(profile_path),
+            "--workspace",
+            str(tmp_path),
+            "--database",
+            str(database_path),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["result"]["state"]["status"] == "failed"
+    assert payload["result"]["state"]["terminal_error"]["code"] == "budget_exhausted"
+    assert payload["result"]["state"]["budget_usage"]["model_iterations"] == 0
+    assert database_path.is_file()
+
+
+def test_missing_provider_credentials_are_a_safe_durable_run_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    profile_path = tmp_path / "profile.json"
+    profile = RunProfile(
+        agent_config=agent_config(),
+        budget_limits=budget_limits(),
+    )
+    profile_path.write_text(
+        json.dumps(profile.model_dump(mode="json")),
+        encoding="utf-8",
+    )
+    database_path = tmp_path / "events.db"
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "must report missing credentials safely",
+            "--profile",
+            str(profile_path),
+            "--workspace",
+            str(tmp_path),
+            "--database",
+            str(database_path),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    terminal_error = payload["result"]["state"]["terminal_error"]
+    assert terminal_error["code"] == "provider_authentication"
+    assert terminal_error["message"] == "Model Provider credentials are not configured."
+    assert "OPENAI_API_KEY" not in result.output
+    assert database_path.is_file()
+
+
+def test_blank_objective_fails_before_database_or_provider_setup(tmp_path: Path) -> None:
+    profile_path = tmp_path / "profile.json"
+    profile = RunProfile(
+        agent_config=agent_config(),
+        budget_limits=budget_limits(),
+    )
+    profile_path.write_text(
+        json.dumps(profile.model_dump(mode="json")),
+        encoding="utf-8",
+    )
+    database_path = tmp_path / "must-not-be-created.db"
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "   ",
+            "--profile",
+            str(profile_path),
+            "--workspace",
+            str(tmp_path),
+            "--database",
+            str(database_path),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_input"
+    assert not database_path.exists()
+
+
+def _inject_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: ModelProvider,
+) -> None:
+    async def build_with_fake(
+        *,
+        profile_path: str | os.PathLike[str],
+        workspace_path: str | os.PathLike[str],
+        database_path: str | os.PathLike[str],
+    ) -> RunServices:
+        return await build_run_services(
+            profile_path=profile_path,
+            workspace_path=workspace_path,
+            database_path=database_path,
+            model_provider=provider,
+        )
+
+    monkeypatch.setattr(cli_main, "build_run_services", build_with_fake)

--- a/tests/recovery/test_agent_loop_boundaries.py
+++ b/tests/recovery/test_agent_loop_boundaries.py
@@ -20,6 +20,7 @@ from bearagent.adapters.testing import (
 )
 from bearagent.adapters.tools import build_workspace_tools
 from bearagent.application.agent_loop import AgentLoop
+from bearagent.application.run_queries import RunQueryService
 from bearagent.domain.agent import AgentConfig, RunInput
 from bearagent.domain.errors import ErrorCategory, ErrorCode, ErrorInfo
 from bearagent.domain.events import Event
@@ -193,6 +194,10 @@ def test_cancellation_propagates_and_keeps_last_committed_activity_non_terminal(
     assert store.committed_events[-1].event_type == "ModelCallStarted"
     assert "ModelCallFailed" not in store.attempted_types
     assert "RunFailed" not in store.attempted_types
+    inspection = asyncio.run(RunQueryService(store).inspect(store.committed_events[0].run_id))
+    assert inspection.state.status.value == "running"
+    assert inspection.state.activities[-1].status.value == "running"
+    assert inspection.artifacts == ()
 
 
 @pytest.mark.parametrize(
@@ -334,3 +339,6 @@ def test_real_workspace_write_is_not_retried_when_terminal_append_fails(
     assert (workspace / "outputs" / "result.md").read_text(encoding="utf-8") == "complete output\n"
     assert store.attempted_types.count("ToolCallCompleted") == 1
     assert "RunFailed" not in store.attempted_types
+    inspection = asyncio.run(RunQueryService(store).inspect(store.committed_events[0].run_id))
+    assert inspection.state.status.value == "running"
+    assert inspection.artifacts == ()

--- a/tests/security/test_cli_boundaries.py
+++ b/tests/security/test_cli_boundaries.py
@@ -1,0 +1,93 @@
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+
+from tests.store_fixtures import run_created_event
+from typer.testing import CliRunner
+
+from bearagent.adapters.sqlite import SqliteEventStore
+from bearagent.domain.ids import RunId
+from bearagent.interfaces.cli.main import app
+
+runner = CliRunner()
+
+
+def test_invalid_profile_does_not_echo_secret_fields_or_host_paths(tmp_path: Path) -> None:
+    secret = "private-profile-secret-value"
+    profile_path = tmp_path / "sensitive-profile-name.json"
+    profile_path.write_text(json.dumps({"api_key": secret}), encoding="utf-8")
+    database_path = tmp_path / "must-not-be-created.db"
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "objective that must not be persisted",
+            "--profile",
+            str(profile_path),
+            "--workspace",
+            str(tmp_path),
+            "--database",
+            str(database_path),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "invalid_input"
+    assert secret not in result.output
+    assert str(profile_path) not in result.output
+    assert not database_path.exists()
+
+
+def test_corrupt_event_query_returns_only_safe_persistence_error(tmp_path: Path) -> None:
+    database_path = tmp_path / "private-database-name.sqlite3"
+    event = run_created_event(RunId.new())
+
+    async def seed() -> None:
+        store = SqliteEventStore(database_path)
+        await store.initialize()
+        await store.append(event)
+
+    asyncio.run(seed())
+    sensitive = "secret-corrupt-event-payload"
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            "UPDATE events SET payload_json = ? WHERE event_id = ?",
+            (sensitive, str(event.event_id)),
+        )
+
+    result = runner.invoke(
+        app,
+        ["run", "events", str(event.run_id), "--database", str(database_path), "--json"],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["error"]["category"] == "persistence"
+    assert sensitive not in result.output
+    assert str(database_path) not in result.output
+    assert "SELECT" not in result.output
+
+
+def test_future_database_migration_fails_without_schema_details(tmp_path: Path) -> None:
+    database_path = tmp_path / "future.sqlite3"
+    asyncio.run(SqliteEventStore(database_path).initialize())
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            "INSERT INTO schema_migrations(version, name, checksum) VALUES (?, ?, ?)",
+            (2, "private-future-migration.sql", "a" * 64),
+        )
+
+    result = runner.invoke(
+        app,
+        ["run", "inspect", str(RunId.new()), "--database", str(database_path), "--json"],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["error"]["category"] == "persistence"
+    assert "private-future-migration" not in result.output
+    assert str(database_path) not in result.output

--- a/tests/security/test_model_provider.py
+++ b/tests/security/test_model_provider.py
@@ -4,8 +4,9 @@ from collections.abc import AsyncIterator
 
 import httpx
 import pytest
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, OpenAIError
 
+import bearagent.adapters.model.openai_responses as provider_module
 from bearagent.adapters.model import OpenAIResponsesProvider
 from bearagent.domain.messages import Message, MessageRole, TextPart
 from bearagent.domain.model import ModelEvent, ModelRequest
@@ -162,3 +163,22 @@ def test_provider_stream_error_ignores_untrusted_message() -> None:
 
     assert caught.value.info.retryable is True
     assert "secret-bearing Provider message" not in caught.value.info.model_dump_json()
+
+
+def test_lazy_client_configuration_failure_is_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = "sensitive-local-provider-configuration"
+
+    def fail_client_creation(**_kwargs: object) -> AsyncOpenAI:
+        raise OpenAIError(secret)
+
+    monkeypatch.setattr(provider_module, "AsyncOpenAI", fail_client_creation)
+    provider = OpenAIResponsesProvider()
+
+    with pytest.raises(ModelProviderError) as caught:
+        asyncio.run(collect(provider))
+
+    assert caught.value.info.code.value == "provider_authentication"
+    assert caught.value.info.message == "Model Provider credentials are not configured."
+    assert secret not in caught.value.info.model_dump_json()

--- a/tests/unit/test_agent_loop.py
+++ b/tests/unit/test_agent_loop.py
@@ -11,7 +11,7 @@ from bearagent.adapters.testing import (
 from bearagent.application.agent_loop import AgentLoop
 from bearagent.domain.agent import AgentConfig, ModelPricing, RunInput
 from bearagent.domain.errors import ErrorCategory, ErrorCode, ErrorInfo
-from bearagent.domain.ids import SessionId, ToolCallId
+from bearagent.domain.ids import RunId, SessionId, ToolCallId
 from bearagent.domain.messages import MessageRole, ToolResultPart
 from bearagent.domain.model import (
     ModelCompleted,
@@ -150,6 +150,25 @@ def test_agent_loop_persists_a_text_run_and_deterministic_cost() -> None:
     assert all(event.schema_version == 2 for event in events)
     requested = parse_run_event_payload(events[2])
     assert requested.request == provider.requests[0]  # type: ignore[union-attr]
+
+
+def test_agent_loop_accepts_a_trusted_preallocated_run_id() -> None:
+    provider = ScriptedFakeModelProvider(
+        [[ModelTextDelta(text="done"), completed(ModelFinishReason.STOP)]]
+    )
+    store = InMemoryEventStore()
+    loop = AgentLoop(
+        model_provider=provider,
+        event_store=store,
+        tool_executor=executor(),
+        clock=TickingClock(),
+    )
+    run_id = RunId.new()
+
+    result = asyncio.run(loop.run(run_input(), run_id=run_id))
+
+    assert result.run_id == run_id
+    assert asyncio.run(store.get_run(run_id)) == result.state
 
 
 def test_agent_loop_executes_tool_then_rebuilds_context_for_final_answer() -> None:

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -1,0 +1,133 @@
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+from tests.agent_loop_fixtures import (
+    agent_config,
+    agent_run_input,
+    budget_limits,
+    model_completed,
+)
+
+import bearagent.bootstrap as bootstrap_module
+from bearagent.adapters.testing import FakeModelProvider
+from bearagent.application import RunQueryError
+from bearagent.bootstrap import (
+    BootstrapError,
+    build_run_query_service,
+    build_run_services,
+    load_run_profile,
+)
+from bearagent.domain.agent import RunProfile
+from bearagent.domain.errors import ErrorCode
+from bearagent.domain.ids import RunId
+from bearagent.domain.model import ModelFinishReason, ModelTextDelta
+
+
+def _write_profile(path: Path, **extra: object) -> RunProfile:
+    profile = RunProfile(
+        agent_config=agent_config(),
+        budget_limits=budget_limits(),
+    )
+    data = {**profile.model_dump(mode="json"), **extra}
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return profile
+
+
+def test_profile_loader_accepts_only_bounded_non_secret_json(tmp_path: Path) -> None:
+    profile_path = tmp_path / "profile.json"
+    expected = _write_profile(profile_path)
+
+    assert load_run_profile(profile_path) == expected
+
+    _write_profile(profile_path, api_key="must-not-enter-profile")
+    with pytest.raises(BootstrapError) as captured:
+        load_run_profile(profile_path)
+    assert captured.value.info.code is ErrorCode.INVALID_INPUT
+    assert "api_key" not in str(captured.value)
+
+
+@pytest.mark.parametrize(
+    "content",
+    [b"\xff\xfe", b"{" + b"x" * (128 * 1_024)],
+    ids=("invalid-utf8", "oversized"),
+)
+def test_profile_loader_rejects_invalid_or_oversized_bytes(
+    tmp_path: Path,
+    content: bytes,
+) -> None:
+    profile_path = tmp_path / "profile.json"
+    profile_path.write_bytes(content)
+
+    with pytest.raises(BootstrapError) as captured:
+        load_run_profile(profile_path)
+
+    assert captured.value.info.code is ErrorCode.INVALID_INPUT
+    assert str(profile_path) not in str(captured.value)
+
+
+def test_profile_loader_rejects_a_link_instead_of_following_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "target.json"
+    link = tmp_path / "profile.json"
+    _write_profile(target)
+    try:
+        link.symlink_to(target)
+    except OSError:
+        # Some Windows hosts deny test symlink creation. Exercise the same
+        # fail-closed branch while workspace link tests cover real reparse paths.
+        def report_link_like(_path: Path, _stat: os.stat_result) -> bool:
+            return True
+
+        link = target
+        monkeypatch.setattr(bootstrap_module, "_is_link_like", report_link_like)
+
+    with pytest.raises(BootstrapError) as captured:
+        load_run_profile(link)
+
+    assert captured.value.info.code is ErrorCode.INVALID_INPUT
+
+
+def test_build_run_services_uses_injected_provider_and_one_sqlite_store(
+    tmp_path: Path,
+) -> None:
+    profile_path = tmp_path / "profile.json"
+    expected = _write_profile(profile_path)
+    database_path = tmp_path / "data" / "bearagent.db"
+    provider = FakeModelProvider(
+        (
+            ModelTextDelta(text="done"),
+            model_completed(ModelFinishReason.STOP),
+        )
+    )
+
+    services = asyncio.run(
+        build_run_services(
+            profile_path=profile_path,
+            workspace_path=tmp_path,
+            database_path=database_path,
+            model_provider=provider,
+        )
+    )
+
+    assert services.profile == expected
+    assert database_path.is_file()
+    asyncio.run(services.agent_loop.run(agent_run_input()))
+    assert tuple(tool.name for tool in provider.requests[0].tools) == ("workspace.read",)
+    with pytest.raises(RunQueryError) as captured:
+        asyncio.run(services.queries.inspect(RunId.new()))
+    assert captured.value.info.code is ErrorCode.RUN_NOT_FOUND
+
+
+def test_query_bootstrap_does_not_create_a_missing_database(tmp_path: Path) -> None:
+    database_path = tmp_path / "missing" / "bearagent.db"
+
+    with pytest.raises(BootstrapError) as captured:
+        asyncio.run(build_run_query_service(database_path))
+
+    assert captured.value.info.code is ErrorCode.PERSISTENCE_ERROR
+    assert not database_path.exists()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -16,6 +16,15 @@ def test_help_exposes_doctor_command() -> None:
     assert "doctor" in result.stdout
 
 
+def test_run_help_explains_objective_and_query_subcommands() -> None:
+    result = runner.invoke(app, ["run", "--help"])
+
+    assert result.exit_code == 0
+    assert "bearagent run OBJECTIVE" in result.stdout
+    assert "inspect" in result.stdout
+    assert "events" in result.stdout
+
+
 def test_version_matches_installed_package() -> None:
     result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0

--- a/tests/unit/test_run_queries.py
+++ b/tests/unit/test_run_queries.py
@@ -1,0 +1,136 @@
+import asyncio
+
+import pytest
+from pydantic import ValidationError
+from tests.store_fixtures import successful_run_events
+
+from bearagent.adapters.testing import InMemoryEventStore
+from bearagent.application.run_queries import RunQueryError, RunQueryService
+from bearagent.domain.errors import ErrorCode
+from bearagent.domain.ids import RunId
+from bearagent.domain.queries import EventPage, RunInspection
+
+
+def test_inspect_returns_the_store_projection_without_a_second_state_model() -> None:
+    async def exercise() -> None:
+        store = InMemoryEventStore()
+        events = successful_run_events()
+        for event in events:
+            await store.append(event)
+
+        result = await RunQueryService(store).inspect(events[0].run_id)
+
+        assert isinstance(result, RunInspection)
+        assert result.state == await store.get_run(events[0].run_id)
+        assert result.run_id == events[0].run_id
+        assert result.artifacts == ()
+
+    asyncio.run(exercise())
+
+
+def test_events_returns_a_bounded_page_and_cursor() -> None:
+    async def exercise() -> None:
+        store = InMemoryEventStore()
+        events = successful_run_events()
+        for event in events:
+            await store.append(event)
+
+        page = await RunQueryService(store).events(
+            events[0].run_id,
+            after_sequence=3,
+            limit=2,
+        )
+
+        assert isinstance(page, EventPage)
+        assert [event.sequence for event in page.events] == [4, 5]
+        assert page.after_sequence == 3
+        assert page.next_after_sequence == 5
+        assert page.has_more is True
+
+        final_page = await RunQueryService(store).events(
+            events[0].run_id,
+            after_sequence=8,
+            limit=2,
+        )
+        assert [event.sequence for event in final_page.events] == [9]
+        assert final_page.next_after_sequence == 9
+        assert final_page.has_more is False
+
+    asyncio.run(exercise())
+
+
+def test_query_rejects_a_missing_run_with_a_stable_safe_error() -> None:
+    async def exercise() -> None:
+        service = RunQueryService(InMemoryEventStore())
+
+        with pytest.raises(RunQueryError) as captured:
+            await service.inspect(RunId.new())
+
+        assert captured.value.info.code is ErrorCode.RUN_NOT_FOUND
+        assert captured.value.info.details == {}
+
+    asyncio.run(exercise())
+
+
+def test_event_page_rejects_cross_run_or_non_contiguous_events() -> None:
+    events = successful_run_events()
+
+    with pytest.raises(ValidationError):
+        EventPage(
+            run_id=RunId.new(),
+            after_sequence=0,
+            limit=2,
+            events=events[:2],
+            next_after_sequence=2,
+            has_more=True,
+        )
+
+    with pytest.raises(ValidationError):
+        EventPage(
+            run_id=events[0].run_id,
+            after_sequence=0,
+            limit=2,
+            events=(events[0], events[2]),
+            next_after_sequence=3,
+            has_more=True,
+        )
+
+
+def test_inspect_fails_instead_of_returning_partial_artifacts_above_limit() -> None:
+    class OversizedRunStore(InMemoryEventStore):
+        def __init__(self) -> None:
+            super().__init__()
+            self.list_called = False
+
+        async def list_events(
+            self,
+            run_id: RunId,
+            *,
+            after_sequence: int = 0,
+            limit: int = 1_000,
+        ):
+            self.list_called = True
+            return await super().list_events(
+                run_id,
+                after_sequence=after_sequence,
+                limit=limit,
+            )
+
+        async def get_run(self, run_id: RunId):
+            state = await super().get_run(run_id)
+            assert state is not None
+            return state.model_copy(update={"last_sequence": 10_001})
+
+    async def exercise() -> None:
+        store = OversizedRunStore()
+        events = successful_run_events()
+        for event in events:
+            await store.append(event)
+
+        with pytest.raises(RunQueryError) as captured:
+            await RunQueryService(store).inspect(events[0].run_id)
+
+        assert captured.value.info.code is ErrorCode.QUERY_LIMIT_EXCEEDED
+        assert store.list_called is False
+
+    asyncio.run(exercise())


### PR DESCRIPTION
## Summary
- add production bearagent run OBJECTIVE, run inspect, and run events commands
- add strict non-secret Run profiles, SQLite-backed query services, stable human/JSON contracts, and safe Provider startup failures
- validate production composition with Fake Provider, real SQLite/workspace Tools, recovery/security coverage, docs, and wheel smoke

## Validation
- uv lock --check
- uv run ruff format --check .
- uv run ruff check .
- uv run pyright
- uv run pytest (348 passed)
- domain/CLI schema generation is idempotent
- docs check (89 Markdown files)
- Starlight build (34 pages)
- sdist/wheel build and isolated installed-wheel CLI smoke

## Boundaries
- no real Provider credentials or model API calls were used
- F-0005 is complete; P1 remains in progress pending the real-model API/gate decision and full Reality Check