### PR TITLE
Clarify default CLI setup and model invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <p><strong>让个人 Agent 在本地可靠地完成长任务。</strong></p>
   <p>每一步可查看 · 结果不明时不乱重试 · 危险操作不由模型授权</p>
   <p>
-    <a href="#项目状态"><img alt="P1 complete" src="https://img.shields.io/badge/status-P1%20complete-16A34A"></a>
+    <a href="#当前已经实现"><img alt="Local CLI ready" src="https://img.shields.io/badge/status-local%20CLI%20ready-16A34A"></a>
     <a href="https://www.python.org/"><img alt="Python 3.12" src="https://img.shields.io/badge/python-3.12-3776AB?logo=python&amp;logoColor=white"></a>
     <a href="https://docs.astral.sh/uv/"><img alt="uv" src="https://img.shields.io/badge/package%20manager-uv-DE5FE9"></a>
     <a href="https://github.com/CherryYang05/BearAgent/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/CherryYang05/BearAgent/actions/workflows/ci.yml/badge.svg"></a>
@@ -23,35 +23,11 @@ BearAgent 是一个 local-first 的个人 Agent Runtime。它把模型调用、T
 当前第一个可用场景是仓库与本地文档研究：Agent 可以在指定 workspace 中查找、读取和比较资料，
 并且只向 `outputs/**` 写入结果。
 
-> [!IMPORTANT]
-> P1 已完成可检查执行。进程重启后自动恢复、Attempt、`UNKNOWN`、用户 Approval 和隔离 runner
-> 仍未实现；这些分别属于 P2 和 P3。
-
-## 现在可以做什么
-
-- 从 CLI 启动一次本地文件 Run，并用 `inspect/events` 查看同一批已保存事实；
-- 使用 SQLite 保存 Event 和 projection，查看每次模型/Tool Activity、预算、Error 与 Artifact；
-- 显式选择 Responses、Chat Completions 或 Anthropic Messages 协议，不根据厂商或 URL 猜测；
-- 通过默认拒绝 Policy 和 workspace 边界阻止路径逃逸、外部写入与 host code execution；
-- 使用 model/tool/token/cost/time hard budget，让 Agent Loop 在明确上限内结束。
-
-```powershell
-uv run bearagent run "阅读 docs，并把项目简介写到 outputs/intro.md" `
-  --config data/config.json `
-  --profile data/p1-run-profile.json
-
-uv run bearagent run inspect <run-id> --json
-uv run bearagent run events <run-id> --after-sequence 0 --limit 100 --json
-```
-
-P1 的 Fake Provider 任务与真实模型 gate 都通过 5/5。真实 gate 的脱敏证据位于
-[F-0017 P1 live report](docs/evidence/F-0017-p1-live-report-v1.json)。
-
 ## 快速开始
 
 需要 [Git](https://git-scm.com/)、[uv](https://docs.astral.sh/uv/) 和 Python 3.12：
 
-```powershell
+```console
 git clone https://github.com/CherryYang05/BearAgent.git
 cd BearAgent
 uv python install 3.12
@@ -59,22 +35,54 @@ uv sync --all-groups --locked
 uv run bearagent doctor
 ```
 
-复制配置模板：
+### 1. 准备本地配置
 
-```powershell
-Copy-Item config.example.json data/config.json
-Copy-Item examples/run-profile-v2.example.json data/p1-run-profile.json
+第一次运行前准备两个本机文件：
+
+- 将根目录的 `config.example.json` 复制为 `data/config.json`；
+- 将 `examples/run-profile-v2.example.json` 复制为 `data/p1-run-profile.json`。
+
+在 `data/config.json` 中填写模型服务的 protocol、base URL、API key、model 和默认 model。在
+`data/p1-run-profile.json` 中选择同一个 `provider_id`，并设置 Agent 指令、可用 Tool 和预算。
+
+> [!IMPORTANT]
+> 示例 RunProfile 的预算全部是 0。要真正调用大模型，必须先把模型次数、token、时间和 Tool 次数
+> 等预算改为你愿意承担的非零上限。
+
+这两个默认文件都位于 Git 忽略的 `data/` 目录。API key 只应保存在本机的 `data/config.json` 中。
+字段说明见[配置参考](docs/reference/configuration.md)。
+
+### 2. 从命令行调用模型
+
+```console
+uv run bearagent run "阅读 docs，并把项目简介写到 outputs/intro.md"
 ```
 
-然后编辑两份本机文件：
+BearAgent 会自动读取 `data/config.json` 和 `data/p1-run-profile.json`，使用当前目录作为 workspace，
+并把 Event 保存到 `data/bearagent.db`。只有需要临时使用其他文件时，才需要传 `--config`、`--profile`、
+`--workspace` 或 `--database`。
 
-1. 在 `data/config.json` 中填写 Provider 的 protocol、base URL、API key、model 和默认 model；
-2. 在 `data/p1-run-profile.json` 中选择 `provider_id`，并按任务设置预算和 Tool 名单；
-3. 运行上面的 `bearagent run` 命令。
+命令结束后会输出 Run ID、最终状态、模型回答和生成的 Artifact。还可以查看保存下来的状态和 Event：
 
-仓库示例故意把预算设为 0，因此未修改时只会生成一个安全、可查询的 `budget_exhausted` Run，不会
-调用模型。字段说明和密钥边界见[配置参考](docs/reference/configuration.md)；完整 CLI 教程见
+```console
+uv run bearagent run inspect <run-id> --json
+uv run bearagent run events <run-id> --after-sequence 0 --limit 100 --json
+```
+
+完整教程见[配置一次模型服务](site/src/content/docs/zh-cn/learn/configure-model-service.md)和
 [运行与检查一次 Run](site/src/content/docs/zh-cn/learn/run-inspect-events.md)。
+
+## 当前已经实现
+
+- 从 CLI 启动一次真实模型文件任务，并用 `inspect/events` 查看同一批已保存事实；
+- 使用 SQLite 保存 Event 和 projection，查看每次模型/Tool Activity、预算、Error 与 Artifact；
+- 显式选择 Responses、Chat Completions 或 Anthropic Messages 协议，不根据厂商或 URL 猜测；
+- 在 workspace 内列出、读取和搜索文件，并且只向 `outputs/**` 原子写入完整结果；
+- 通过默认拒绝 Policy 和 workspace 边界阻止路径逃逸、外部写入与 host code execution；
+- 使用 model/tool/token/cost/time hard budget，让 Agent Loop 在明确上限内结束。
+
+固定离线任务与真实模型任务均通过 5/5。真实模型任务的脱敏证据位于
+[live-model report](docs/evidence/F-0017-p1-live-report-v1.json)。
 
 ## 为什么是 Runtime
 

--- a/docs/specs/F-0017-configurable-model-providers-live-gate.md
+++ b/docs/specs/F-0017-configurable-model-providers-live-gate.md
@@ -5,7 +5,7 @@ spec_id: F-0017
 milestone: P1
 owner: CherryYang05
 created: 2026-08-22
-last_updated: 2026-08-23
+last_updated: 2026-08-25
 implemented_in: "codex/F-0017-p1-live-model-gate"
 related_adrs: [ADR-0004, ADR-0007, ADR-0009, ADR-0010, ADR-0013, ADR-0014, ADR-0015]
 ---
@@ -225,11 +225,10 @@ Responses 请求改成 Chat Completions，不把一个服务的 key 发给另一
 
 ```text
 bearagent run OBJECTIVE
-  --profile data/p1-run-profile.json
-  --config data/config.json
 ```
 
-两个路径有默认值。CLI 不增加 `--api-key`、`--protocol`、`--base-url` 或厂商专属参数。
+CLI 默认读取 `data/p1-run-profile.json` 和 `data/config.json`；只有临时使用其他文件时才需要用
+`--profile` 或 `--config` 覆盖。CLI 不增加 `--api-key`、`--protocol`、`--base-url` 或厂商专属参数。
 
 ```text
 RunProfile v2 --provider_id--┐

--- a/site/src/content/docs/zh-cn/development/run-cli.md
+++ b/site/src/content/docs/zh-cn/development/run-cli.md
@@ -36,10 +36,10 @@ Anthropic Messages adapter。它不根据厂商、URL 或 model 猜协议，也�
 随后 composition 选择 profile 明确列出的 Tool。未配置的 Tool 不进入 Registry，因此既不会出现在
 ModelRequest 中，也不会被 Policy 允许。同一个 SQLite Store 同时交给 AgentLoop 和 RunQueryService。
 
-测试可以注入 Provider-neutral Fake Provider；真实 CLI 不暴露 `--api-key`，只从选中条目指定的环境
-变量读取 key。SDK client 延迟到首个模型 Activity；零预算不创建 client，缺 key 时首个 Activity/Run
-保存安全的 `provider_authentication`。domain、runtime 和 application 不导入 OpenAI/Anthropic、
-SQLite adapter 或 Typer；architecture test 持续检查这个方向。
+测试可以注入 Provider-neutral Fake Provider；真实 CLI 不暴露 `--api-key`，只从被 Git 忽略的本机
+`data/config.json` 中读取所选 Provider 的 key。SDK client 延迟到首个模型 Activity；零预算不创建
+client，缺 key 时在数据库和 Run 创建前安全失败。domain、runtime 和 application 不导入
+OpenAI/Anthropic、SQLite adapter 或 Typer；architecture test 持续检查这个方向。
 
 Profile 与 catalog loader 都使用文件描述符读取最多 128 KiB，并比较打开前后快照。链接、reparse
 point、替换竞态、非法 UTF-8、未知字段、非法 URL/key 和未知字段都会变成有限的 safe Error。

--- a/site/src/content/docs/zh-cn/learn/configure-model-service.md
+++ b/site/src/content/docs/zh-cn/learn/configure-model-service.md
@@ -99,14 +99,16 @@ RunProfile v2 不接受 `agent_config.model` 或 `agent_config.pricing`。Bootst
 
 ## 第三步：运行并检查
 
-```powershell
-uv run bearagent run "阅读 docs，并把总结写到 outputs/summary.md" `
-  --profile data/p1-run-profile.json `
-  --config data/config.json
+CLI 默认读取 `data/config.json` 和 `data/p1-run-profile.json`，因此正常运行不需要重复传路径：
+
+```console
+uv run bearagent run "阅读 docs，并把总结写到 outputs/summary.md"
 
 uv run bearagent run inspect <run-id> --json
 uv run bearagent run events <run-id> --json
 ```
+
+只有临时使用其他配置时，才需要用 `--config` 或 `--profile` 覆盖默认路径。
 
 缺少、空白或非法 key 时，config 会在创建数据库和 Run 前失败。v2 Run 只用 Event schema v3 保存
 `provider_id`、自动计算的 `config_version` 和 `protocol`，不会保存 base URL、key 或 HTTP header。

--- a/site/src/content/docs/zh-cn/learn/run-inspect-events.md
+++ b/site/src/content/docs/zh-cn/learn/run-inspect-events.md
@@ -14,10 +14,12 @@ sourceRefs:
 是什么、最终状态是什么、哪些事实真的保存下来了。F-0005 用三个命令回答它们：
 
 ```powershell
-bearagent run "阅读 docs 并把总结写到 outputs/summary.md" --config data/config.json
+bearagent run "阅读 docs 并把总结写到 outputs/summary.md"
 bearagent run inspect <run-id>
 bearagent run events <run-id> --after-sequence 0 --limit 100
 ```
+
+第一条命令默认读取 `data/config.json` 和 `data/p1-run-profile.json`，不需要每次重复传入路径。
 
 ## 一次命令怎样接到已有边界
 

--- a/tests/integration/test_run_cli.py
+++ b/tests/integration/test_run_cli.py
@@ -109,6 +109,63 @@ def test_fake_provider_cli_run_then_inspect_and_page_events(
     assert event_payload["result"]["has_more"] is False
 
 
+def test_run_uses_default_local_configuration_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_path = tmp_path / "data"
+    data_path.mkdir()
+    profile = RunProfileV2(
+        provider_id="primary",
+        agent_config=agent_settings(),
+        budget_limits=budget_limits(),
+    )
+    (data_path / "p1-run-profile.json").write_text(
+        json.dumps(profile.model_dump(mode="json")),
+        encoding="utf-8",
+    )
+    (data_path / "config.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "providers": [
+                    {
+                        "provider_id": "primary",
+                        "name": "Test Provider",
+                        "protocol": "openai_responses",
+                        "base_url": "https://example.com/v1",
+                        "api_key": "test-key",
+                        "models": [{"model_id": "test-model"}],
+                        "default_model": "test-model",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    provider = ScriptedFakeModelProvider(
+        [
+            (
+                ModelTextDelta(text="Default paths work."),
+                ModelCompleted(
+                    provider_request_id="fake-default-paths",
+                    model="test-model",
+                    finish_reason=ModelFinishReason.STOP,
+                    usage=ModelUsage(input_tokens=4, output_tokens=3),
+                ),
+            )
+        ]
+    )
+    _inject_provider(monkeypatch, provider)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["run", "--json", "use the default files"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["result"]["final_text"] == "Default paths work."
+    assert (data_path / "bearagent.db").is_file()
+
+
 def test_run_group_preserves_inspect_and_rejects_invalid_ids_as_safe_json(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- move the real model CLI workflow to the top of the README and describe current capabilities without opening with milestone reporting
- explain the cross-platform copy destinations for config.json and the RunProfile without prescribing PowerShell commands
- use the existing default data/config.json, data/p1-run-profile.json, and data/bearagent.db paths in all normal run examples
- add an integration test proving bearagent run works without explicit path options and creates the default database
- synchronize the F-0017 external interface and CLI learning/developer pages

## Validation

- 446 tests passed
- Ruff format and lint passed
- Pyright: 0 errors
- 126 Markdown files passed local-link validation
- Starlight built 36 pages
- git diff --check passed