### PR TITLE
feat(diagnostics): add safe structured runtime logs

### DIFF
--- a/docs/adr/ADR-0017-event-ledger-with-best-effort-ops-diagnostics.md
+++ b/docs/adr/ADR-0017-event-ledger-with-best-effort-ops-diagnostics.md
@@ -1,0 +1,106 @@
+---
+title: "ADR-0017: Use Events to confirm execution and diagnostics only for troubleshooting"
+status: accepted
+date: 2026-09-02
+decision_owners: [CherryYang05]
+supersedes: null
+superseded_by: null
+---
+
+# ADR-0017：系统只用 Event 确认执行结果，诊断日志只帮助排错
+
+## 要解决的问题
+
+BearAgent 已用 EventStore 保存模型、Tool、预算、Error 和 Artifact 事实，但配置读取、数据库初始化与
+adapter 内部错误可能发生在 Event 之前或之外。若 Runtime 再写一份包含请求、响应和状态的通用日志，
+Event、日志和 CLI 会形成三套含义；崩溃后调用方还可能把先于 transaction 输出的日志误当成已提交事实。
+
+另一方面，完全没有统一运行诊断会让开发者难以定位 bootstrap、persistence 和 CLI 边界失败。现在必须
+说清楚：哪些信息会影响系统对 Run 的判断，哪些信息只给开发者排错，以及两者如何用 ID 关联。
+
+## 选择时最看重什么
+
+- 可维护性：Run 状态只根据 Event 判断，不让每个模块自由发明日志字段；
+- 恢复语义：日志存在、缺失或乱序都不影响 Reducer 和恢复判断；
+- 安全：默认结构从类型上排除正文、原始异常、路径和凭据；
+- 复杂度/交付时间：只用标准库 stderr，不引入遥测 SDK、collector 或日志数据库；
+- 兼容与迁移：不改变 Event、CLI JSON、SQLite schema 和历史 Run。
+
+## 比较过的方案
+
+### 方案 A：把 Agent Loop 全量复制为 JSONL 日志
+
+它易于人工查看，也能携带 Prompt、Tool 参数和响应。但这些内容已经在 Event 中有明确版本和 byte
+边界；复制会增加泄密面、顺序分叉和日志保留责任，且无法与 Event transaction 原子提交。
+
+### 方案 B：Event 保存执行记录，固定字段日志帮助排错
+
+已提交 Event 只导出 envelope、关联 ID、耗时与安全错误码；没有 Event 归宿的 bootstrap/adapter/CLI
+问题使用单独 operation record。两类 record 都不能参与状态和恢复。代价是日志不能单独重放完整 Run，
+排查业务事实时仍需使用 `inspect/events`。
+
+### 方案 C：立即接入 OpenTelemetry logs、metrics 和 traces
+
+它能提供 exporter、span 和现成后端，但 P1 只有单进程 CLI，尚无 collector、sampling、远程数据边界
+或运维需求。现在引入会把遥测生命周期和新生产依赖带入 Runtime；P5 才有跨版本 trace 的退出证据。
+
+## 决定
+
+选择方案 B，并规定：
+
+1. 系统只根据 Event 判断 Run 做到了哪里、用了多少预算，以及中断后能否继续。DiagnosticRecord 只在
+   当前进程中输出，即使没有写出来或后来被清理，也不能进入 Reducer、Context、Checkpoint、恢复或
+   授权流程。
+2. EventStore decorator 只能在 delegate append 成功后发出 `event.committed`。append 失败必须使用
+   `event.append_failed`，不得假装 Event 已存在。
+3. DiagnosticRecord 是冻结的 BearAgent 类型，只允许固定版本、时间、级别、组件、操作、关联 ID、
+   Event 元数据、耗时、错误码和异常类型。它没有任意 message、details 或 payload 容器。
+4. 默认 adapter 把一行一个 JSON object 写到 stderr，并限制整行 byte。CLI stdout contract 不变。
+5. 所有 sink 调用都经 fail-open 隔离；sink 失败不能回滚 Event、终止 Run、改变 query，也不能触发重试。
+6. bootstrap 是默认 sink 与 EventStore decorator 的 composition root。domain、runtime 和 application
+   不导入具体日志 adapter；AgentLoop 不增加 logger 分支。
+7. Activity 耗时可以由同一进程中已提交的 started/terminal Event 对计算，但只是诊断近似值；Event
+   `occurred_at` 和 sequence 仍是事实。缺失 started record 时省略耗时，不猜测。
+8. 默认不记录 traceback、Prompt、模型文本、Tool 参数/结果、Error message/details、Provider response、
+   路径、配置或环境变量。未来 debug traceback 必须显式启用并另行定义脱敏和保留边界。
+9. P5 可以增加从 committed Event 派生的 ledger exporter 和可选 OpenTelemetry span；不得让 exporter
+   反向成为 Runtime 依赖或恢复事实。
+
+这个决定与 DeepSeek Harness 把 session ledger 与 ops channel 分开的做法一致，也采用 Claude Code
+默认关闭详细 trace 和内容导出的安全方向；外部实现只提供比较，不证明 BearAgent 当前能力：
+
+- <https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/subsystems/session-telemetry.md>
+- <https://code.claude.com/docs/en/monitoring-usage>
+
+## 带来的影响
+
+### 得到的好处
+
+- 运行失败有统一、可关联且可机器解析的 stderr 信号；
+- Event payload 不会被复制到第二套默认记录；
+- sink 不可用时 Runtime 行为保持不变；
+- 未来 OTel exporter 可以接在稳定 record/Event 投影之后，而不是侵入 AgentLoop。
+
+### 接受的代价
+
+- stderr JSON Lines 不提供文件轮转、查询 UI 或跨进程 trace；
+- 日志不能独立重放 Run，完整调查仍要查询 EventStore；
+- Event 提交后，进程可能在日志输出前立即退出，因此少一行日志是允许的；已提交 Event 不受影响；
+- Activity duration 是当前进程内近似值，不是持久 SLA 证据。
+
+## 迁移和回退
+
+没有数据库、Event 或 CLI JSON migration。默认 stderr 输出是新增的可观察行为；嵌入调用可注入 Null
+sink。回退可以移除 decorator 和 adapter，但必须保留既有 Event/Reducer/CLI 查询语义，不能从日志补写
+或删除历史事实。
+
+## 怎样验证
+
+- spy store 证明 committed record 只在 delegate append 成功后出现；
+- failing sink 证明 Event、query 和 Run 结果不受影响；
+- security tests 向 objective、Tool payload、异常、路径和环境注入 marker，再扫描全部 diagnostics；
+- CLI integration 证明 stdout 仍是原 human/JSON contract，stderr 每条 diagnostic 可解析且字段封闭；
+- schema、migration、import-boundary、Ruff、Pyright、pytest、governance 和文档构建继续通过；
+- P5 开始时重新评估 OTel、远程 exporter、sampling、trace propagation 和保留期。
+
+项目所有者于 2026-09-02 要求按该收窄方案实现，接受本决定。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,6 +25,8 @@ ADR 只记录影响多个模块、以后难以反转的技术决定。标题直�
   — accepted
 - [ADR-0016：Run 创建时保存可信契约身份，进程中断后只报告已提交事实](ADR-0016-run-contract-fingerprint-committed-crash-facts.md)
   — accepted
+- [ADR-0017：系统只用 Event 确认执行结果，诊断日志只帮助排错](ADR-0017-event-ledger-with-best-effort-ops-diagnostics.md)
+  — accepted
 
 新决定使用 [ADR 模板](../templates/adr.md)。被新决定替代的 ADR 不删除，改为 `superseded` 并链接
 到替代它的文档。

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -54,6 +54,7 @@ flowchart TB
 | 固定任务 | 五个版本化文件任务使用 Fake Provider 完成确定性验证；DeepSeek V4 suite v1.1.1 也通过同一 rubric 的真实 5/5 |
 | 用户入口 | `run/inspect/events` CLI、config v1、RunProfile v1/v2、human/JSON renderer 和安全退出码 |
 | 查询 | application query service 只通过 EventStore 读取 projection 与分页 Event，并重建 Artifact 元数据 |
+| 运行诊断 | Event 写入数据库后输出固定字段 stderr JSON Lines；另记录 bootstrap/CLI/EventStore 的有限错误码，不复制 payload |
 | 测试替身 | Fake model、Fake tool、内存 Event store |
 | 文档 | 工程 `docs/` 与可静态发布的 Starlight 学习/开发者站点 |
 
@@ -90,7 +91,7 @@ flowchart TB
     TP --> WA["Workspace tools"]
     TP --> SR["Sandbox runner - P3"]
     EP --> SQ["SQLite adapter"]
-    K --> O["Logs / trace / eval export"]
+    K --> O["Best-effort diagnostics / future trace"]
 ```
 
 ### 4.1 Core、port 和 adapter
@@ -415,16 +416,22 @@ P4 才增加 Run 创建、查询、Event stream、取消、Approval 和 Artifact
 Run。SSE 通过持久 Event sequence 续接，不只依赖内存 token stream。P3 先通过 CLI 完成授权和隔离
 闭环，避免把核心安全语义与公网服务一起调试。
 
-## 14. Event、trace 和评测不是一件事
+## 14. Event、Log、Trace 和评测不是一件事
 
 ```text
-Event      已经发生的领域事实，也是恢复依据
-Trace      调用嵌套、耗时和 Provider/Tool 诊断
-Checkpoint 加快状态重建的快照
+Event       已经发生的领域事实，也是恢复依据
+Log         帮助定位组件和操作为何失败；缺失不改变 Run
+Trace       调用嵌套、耗时和 Provider/Tool 路径
+Checkpoint  加快状态重建的快照
 ```
 
-P1 从固定任务、结构化日志和 Event 查询开始；P2 增加中断恢复断言；P3 增加权限和隔离断言；P5
-再接入 OpenTelemetry 和跨版本报告。
+F-0031 的结构化 Log 只输出固定字段：组件、操作、Run/Event/Activity 关联 ID、Event type、sequence、
+有限耗时、错误码和异常类型。只有 Event 成功写入数据库后，才会输出对应日志；日志没有 payload、
+message、details、路径或 traceback。即使 stderr 不可写或少了一行日志，Event、Run 和查询结果也保持
+不变。要确认 Run 实际做过什么，仍使用 `inspect/events`；Runtime 不读取日志来恢复状态。
+
+P1 从固定任务、安全结构化日志和 Event 查询开始；P2 增加中断恢复断言；P3 增加权限和隔离断言；P5
+再接入从 committed Event 派生的 OpenTelemetry、完整 span 路径和跨版本报告。
 
 评测既看最终答案，也看执行路径：是否只使用允许的最小工具集，是否越权，崩溃后是否重复副作用，
 预算和重试是否符合规则，以及 Prompt/Skill/模型版本变化是否造成回归。

--- a/docs/plans/PLAN-F-0031-safe-structured-diagnostics.md
+++ b/docs/plans/PLAN-F-0031-safe-structured-diagnostics.md
@@ -1,10 +1,10 @@
 ---
 title: "Implementation Plan: Safe structured operational diagnostics"
-status: active
+status: completed
 plan_id: PLAN-F-0031
 related_spec: F-0031
 created: 2026-09-02
-last_updated: 2026-09-02
+last_updated: 2026-09-04
 ---
 
 # PLAN-F-0031：安全结构化运行诊断
@@ -85,15 +85,14 @@ npm run build --prefix=site
 git diff --check
 ```
 
-在取得独立 commit/PR 证据前，Feature 保持 `accepted`、Plan 保持 `active`；本 Plan 要准确记录已经完成
-的技术切片，但不把未授权的 commit/push 当作完成证据。
+实现提交 `5d9da00` 已提供独立、不可变的代码证据；以下门禁在该提交的隔离工作树中重新执行。
 
-## 2026-09-02 工作树验证结果
+## 2026-09-04 实现提交验证结果
 
 - `uv run ruff check .`、`uv run ruff format --check .` 和 `uv run pyright` 通过；
-- `uv run pytest -q` 通过 490 个测试；
+- `uv run pytest -q` 通过 483 个测试；
 - 三个 schema generator 运行后 snapshot 无 diff；
-- governance 检查通过 14 个 Spec、13 个 Plan、17 个 ADR；144 个 Markdown 本地链接通过；
+- governance 检查通过 14 个 Spec、13 个 Plan、17 个 ADR；114 个 Markdown 文件的本地链接通过；
 - Starlight 构建 46 页并生成搜索索引；sdist/wheel 构建成功；
-- `git diff --check` 通过；没有 Event/CLI/runtime configuration schema 或 SQLite migration 变化；
-- 当前仍缺独立 commit/PR immutable evidence，因此 Front Matter 按治理规则保持 `accepted` / `active`。
+- 没有 Event/CLI/runtime configuration schema 或 SQLite migration 变化；
+- Feature Front Matter 已记录 `implemented_in: 5d9da00`，Plan 状态改为 `completed`。

--- a/docs/plans/PLAN-F-0031-safe-structured-diagnostics.md
+++ b/docs/plans/PLAN-F-0031-safe-structured-diagnostics.md
@@ -1,0 +1,99 @@
+---
+title: "Implementation Plan: Safe structured operational diagnostics"
+status: active
+plan_id: PLAN-F-0031
+related_spec: F-0031
+created: 2026-09-02
+last_updated: 2026-09-02
+---
+
+# PLAN-F-0031：安全结构化运行诊断
+
+关联 Spec：`docs/specs/F-0031-safe-structured-diagnostics.md`
+
+## 开始前确认
+
+- [x] Spec status is `accepted`.
+- [x] 影响实现的开放问题已经解决。
+- [x] S2 的 ADR 已接受，迁移/回退边界已经明确。
+
+## 实施步骤
+
+### 第 1 步：建立字段封闭的 record、sink port 与标准库 adapter
+
+- 状态：completed；
+- 交付结果：冻结 DiagnosticRecord、sink protocol、Null/JSON Lines adapter 和 fail-open emitter；
+- 代码落点：`domain/diagnostics.py`、`ports/diagnostics.py`、`adapters/diagnostics.py`；
+- 接入关系：外层调用只传 BearAgent record，adapter 只向 stderr 输出固定 JSON；
+- 重点测试：字段校验、byte limit、确定性 JSON、sink failure 隔离；
+- 验证命令：`uv run pytest tests/unit/test_diagnostics.py -q`；
+- 回退方式：删除新增模块，不影响 Event 与数据库。
+
+### 第 2 步：在 EventStore 提交后输出 ledger 元数据
+
+- 状态：completed；
+- 交付结果：decorator 输出 committed/append failed/query failed record，并计算有界耗时；
+- 代码落点：diagnostics adapter 与 production bootstrap；
+- 接入关系：AgentLoop/RunQueryService 继续只依赖同一个 EventStore port；
+- 重点测试：post-commit 顺序、payload 不复制、Activity duration、append/query/sink failure；
+- 验证命令：`uv run pytest tests/unit/test_diagnostics.py tests/unit/test_bootstrap.py -q`；
+- 回退方式：bootstrap 直接恢复使用 SqliteEventStore。
+
+### 第 3 步：接通 CLI/Bootstrap 安全失败并完成安全回归
+
+- 状态：completed；
+- 交付结果：stdout contract 不变，stderr 输出有限 operation error；
+- 代码落点：bootstrap、CLI error boundary、security/integration tests；
+- 接入关系：CLI 仍只调用 application/bootstrap，不读取日志作业务判断；
+- 重点测试：secret/raw exception/path/objective 不泄漏，Null/failing sink 不改变结果；
+- 验证命令：`uv run pytest tests/integration/test_run_cli.py tests/security/test_diagnostics.py -q`；
+- 回退方式：移除最外层诊断调用，保留原安全 Error renderer。
+
+### 第 4 步：同步工程与读者文档并完成全量验证
+
+- 状态：completed；
+- 交付结果：架构、路线图、CLI/开发者页准确区分 Event、Log、Trace；
+- 代码落点：Spec/ADR/Plan、architecture/roadmap、site；
+- 接入关系：文档只解释当前实现，不把 P5 OTel 写成现状；
+- 重点测试：governance、links、Starlight build、全量质量门；
+- 验证命令：见最终验证；
+- 回退方式：随实现回退对应事实说明，不删除历史 Spec/ADR。
+
+## 跨切片检查
+
+| 风险面 | 结果或 `N/A` + 原因 | 证据 |
+|---|---|---|
+| Persistence / recovery | 不改变持久状态；日志永不作为恢复输入 | post-commit/failing sink tests |
+| Permission / security | 固定字段排除正文、路径、secret、原始异常 | security scan |
+| Timeout / cancel / limits | stderr line 有 byte 上限；取消不被 sink 捕获 | unit tests |
+| Migration / rollback | 无 Event/SQLite/CLI JSON migration；可移除 wiring | schema/migration diff |
+| Logs / trace / metrics | 本 Feature 只做本地 logs；OTel/metrics/完整 trace 留在 P5 | ADR-0017 |
+| Documentation impact | 按 Spec 第 9 节逐面同步 | docs/site checks |
+
+## 最终验证
+
+完成前运行并记录：
+
+```text
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest -q
+uv run python scripts/check_governance.py
+uv run python scripts/check_docs.py
+npm run build --prefix=site
+git diff --check
+```
+
+在取得独立 commit/PR 证据前，Feature 保持 `accepted`、Plan 保持 `active`；本 Plan 要准确记录已经完成
+的技术切片，但不把未授权的 commit/push 当作完成证据。
+
+## 2026-09-02 工作树验证结果
+
+- `uv run ruff check .`、`uv run ruff format --check .` 和 `uv run pyright` 通过；
+- `uv run pytest -q` 通过 490 个测试；
+- 三个 schema generator 运行后 snapshot 无 diff；
+- governance 检查通过 14 个 Spec、13 个 Plan、17 个 ADR；144 个 Markdown 本地链接通过；
+- Starlight 构建 46 页并生成搜索索引；sdist/wheel 构建成功；
+- `git diff --check` 通过；没有 Event/CLI/runtime configuration schema 或 SQLite migration 变化；
+- 当前仍缺独立 commit/PR immutable evidence，因此 Front Matter 按治理规则保持 `accepted` / `active`。

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -20,7 +20,9 @@ Plan 不重复 Spec 的需求，也不代替 ADR。开始前确认 Spec 已 `acc
 
 ## 当前计划
 
-当前没有 active Plan。
+当前 active Plan：
+
+- [PLAN-F-0031：安全结构化运行诊断](PLAN-F-0031-safe-structured-diagnostics.md)
 
 ## 已完成计划
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -20,12 +20,11 @@ Plan 不重复 Spec 的需求，也不代替 ADR。开始前确认 Spec 已 `acc
 
 ## 当前计划
 
-当前 active Plan：
-
-- [PLAN-F-0031：安全结构化运行诊断](PLAN-F-0031-safe-structured-diagnostics.md)
+当前没有 active Plan。
 
 ## 已完成计划
 
+- [PLAN-F-0031：安全结构化运行诊断](PLAN-F-0031-safe-structured-diagnostics.md)
 - [PLAN-F-0018：强化 P1 执行契约身份与 crash observability](PLAN-F-0018-p1-evidence-hardening.md)
 - [PLAN-F-0015：建立并重写 Starlight 文档站](PLAN-F-0015-local-starlight-docs-site.md)
 - [PLAN-F-0001：内部 ID、Message、Error 和 Event](PLAN-F-0001-domain-ids-messages-errors.md)

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -87,6 +87,11 @@ P1 只保证已保存事实可查。F-0018 让新 Run 记录可信 Tool/Policy c
 hard-process 测试验证最后 committed fact 的可见性。进程退出后仍不会自动继续；timeout 也不会撤销
 可能已经发生的副作用。
 
+F-0031 是不改变 P1 退出状态的追加 hardening：它补齐 accepted F-0016 中的安全结构化日志，只从已经
+提交的 Event 输出固定 envelope/耗时/错误码，并为 bootstrap、CLI 和 EventStore 边界增加有限运行诊断。
+系统不会读取这些日志来判断 Run 状态或决定 P2 恢复。该 Feature 已接受，当前工作树已经完成质量门，
+active Plan 只等待独立 implementation evidence。
+
 F-0015 提供独立的 Starlight 文档站、渐进式学习路线、CLI 手册和源码导读。它可以本地开发、构建
 和预览，普通 CI 负责验证；在线托管与自动部署不属于 F-0015，也不再作为 P1 的关闭门。
 
@@ -297,6 +302,7 @@ P5 把 P1 任务、P2 恢复演练和 P3 安全演练接入统一追踪，比较
 |---|---|
 | model/tool/token/cost/time hard budget | P1 已实现 |
 | 有界 Context、ToolResult 截断、Tool timeout | P1 已实现 |
+| 本机安全结构化运行诊断 | P1 hardening F-0031 |
 | Attempt、失败分类、retry/backoff | P2 |
 | Checkpoint、启动扫描、resume/cancel | P2 |
 | idempotency、Receipt、reconcile、`UNKNOWN` | P2 |
@@ -306,6 +312,7 @@ P5 把 P1 任务、P2 恢复演练和 P3 安全演练接入统一追踪，比较
 | Skill、MCP、Web、Memory | P4 |
 | Tool routing | P4 出现规模证据后 |
 | generalized loop/progress detection | P4/P5 研究项，不是承诺 |
+| OpenTelemetry、完整 span 和跨版本 trace | P5 |
 | 多 Agent、分布式执行 | P6+ |
 
 ## 11. Feature Backlog
@@ -314,7 +321,7 @@ Feature ID 在 Spec 创建后保持稳定。未创建 Spec 的名称只表示计
 milestone。2026-08-28 为让完成的 P1 Feature 和后续阶段按顺序阅读，项目所有者明确要求把尚未创建
 Spec 的 P2/P3/P4 占位 ID 统一顺延；这次重排不改变任何已接受或已实现 Feature 的 ID。
 
-### P1（基线已完成；pre-P2 hardening 进行中）
+### P1（基线已关闭；F-0031 追加 hardening 进行中）
 
 1. [F-0001：内部 ID、Message 和 Error](../specs/F-0001-domain-ids-messages-errors.md)
 2. [F-0002：Run/Activity 状态和预算](../specs/F-0002-run-reducer-activity-lifecycle-budgets.md)
@@ -328,6 +335,7 @@ Spec 的 P2/P3/P4 占位 ID 统一顺延；这次重排不改变任何已接受�
 10. [F-0016：有界 Context 和串行 Agent Loop](../specs/F-0016-bounded-context-agent-loop.md)
 11. [F-0017：模型服务配置与真实 gate](../specs/F-0017-configurable-model-providers-live-gate.md)
 12. [F-0018：可信 Run contract identity 与 crash observability](../specs/F-0018-p1-evidence-hardening.md) — implemented
+13. [F-0031：安全结构化运行诊断](../specs/F-0031-safe-structured-diagnostics.md) — accepted
 
 F-0015 的文档内容、本地站点、构建和阅读体验已经实现；部署到某个在线平台不在该 Feature 范围内。
 

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -89,8 +89,8 @@ hard-process 测试验证最后 committed fact 的可见性。进程退出后仍
 
 F-0031 是不改变 P1 退出状态的追加 hardening：它补齐 accepted F-0016 中的安全结构化日志，只从已经
 提交的 Event 输出固定 envelope/耗时/错误码，并为 bootstrap、CLI 和 EventStore 边界增加有限运行诊断。
-系统不会读取这些日志来判断 Run 状态或决定 P2 恢复。该 Feature 已接受，当前工作树已经完成质量门，
-active Plan 只等待独立 implementation evidence。
+系统不会读取这些日志来判断 Run 状态或决定 P2 恢复。该 Feature 已实现，implementation evidence 为
+`5d9da00`，对应 Plan 已完成。
 
 F-0015 提供独立的 Starlight 文档站、渐进式学习路线、CLI 手册和源码导读。它可以本地开发、构建
 和预览，普通 CI 负责验证；在线托管与自动部署不属于 F-0015，也不再作为 P1 的关闭门。
@@ -321,7 +321,7 @@ Feature ID 在 Spec 创建后保持稳定。未创建 Spec 的名称只表示计
 milestone。2026-08-28 为让完成的 P1 Feature 和后续阶段按顺序阅读，项目所有者明确要求把尚未创建
 Spec 的 P2/P3/P4 占位 ID 统一顺延；这次重排不改变任何已接受或已实现 Feature 的 ID。
 
-### P1（基线已关闭；F-0031 追加 hardening 进行中）
+### P1（基线已关闭；F-0031 追加 hardening 已完成）
 
 1. [F-0001：内部 ID、Message 和 Error](../specs/F-0001-domain-ids-messages-errors.md)
 2. [F-0002：Run/Activity 状态和预算](../specs/F-0002-run-reducer-activity-lifecycle-budgets.md)
@@ -335,7 +335,7 @@ Spec 的 P2/P3/P4 占位 ID 统一顺延；这次重排不改变任何已接受�
 10. [F-0016：有界 Context 和串行 Agent Loop](../specs/F-0016-bounded-context-agent-loop.md)
 11. [F-0017：模型服务配置与真实 gate](../specs/F-0017-configurable-model-providers-live-gate.md)
 12. [F-0018：可信 Run contract identity 与 crash observability](../specs/F-0018-p1-evidence-hardening.md) — implemented
-13. [F-0031：安全结构化运行诊断](../specs/F-0031-safe-structured-diagnostics.md) — accepted
+13. [F-0031：安全结构化运行诊断](../specs/F-0031-safe-structured-diagnostics.md) — implemented
 
 F-0015 的文档内容、本地站点、构建和阅读体验已经实现；部署到某个在线平台不在该 Feature 范围内。
 

--- a/docs/specs/F-0031-safe-structured-diagnostics.md
+++ b/docs/specs/F-0031-safe-structured-diagnostics.md
@@ -1,0 +1,125 @@
+---
+title: "Feature: Safe structured operational diagnostics"
+status: accepted
+spec_id: F-0031
+milestone: P1
+change_level: S2
+owner: CherryYang05
+created: 2026-09-02
+last_updated: 2026-09-02
+implemented_in: null
+related_adrs: [ADR-0002, ADR-0007, ADR-0013, ADR-0014, ADR-0017]
+---
+
+# F-0031：安全输出结构化运行诊断，而不复制 Event 内容
+
+## 1. 问题与证据
+
+`run/inspect/events` 已经可以查询一次 Run 的持久事实，但配置读取、SQLite 初始化、CLI 边界和
+EventStore adapter 自身失败时，可能还没有 Event 可以查询。开发者只能看到最终安全 Error，无法把
+失败定位到具体组件和操作。
+
+F-0016 已要求默认结构化日志只记录 ID、Event type、sequence、耗时和有限错误码，当前源码却没有统一
+的诊断 record、sink 或 production wiring。若每个模块临时使用 `print`、`console.error` 或任意
+`logging` extra，Prompt、Tool 参数、Provider 响应和原始异常可能被复制到第二套记录中。
+
+## 2. 目标与非目标
+
+### 本次交付
+
+- G-1：定义冻结、字段封闭且有 byte 上限的 `DiagnosticRecord`；它只帮助排错，不作为系统判断
+  Run 状态的记录；
+- G-2：默认把结构化 JSON Lines 写到 stderr，保持 CLI stdout 的 human/JSON contract 不变；
+- G-3：Event 成功提交后输出 Event envelope、Activity ID、耗时和安全错误码，不复制 payload；
+- G-4：配置、组装、查询和 EventStore 失败输出组件、操作、错误码和异常类型，不输出异常文本或堆栈；
+- G-5：任何诊断 sink 失败都与 Run、Event transaction、查询结果和 CLI Error 隔离；
+- G-6：保留注入 `NullDiagnosticSink` 或测试 sink 的入口，便于嵌入调用和确定性测试。
+
+### 本次不做
+
+- NG-1：不新增日志数据库、日志文件、轮转、保留期、后台上传或远程 collector；
+- NG-2：不新增 OpenTelemetry、span exporter、sampling、跨进程 propagation 或 trace UI；
+- NG-3：不新增 `trace` CLI，也不从日志重建 Run、恢复 Activity、决定 retry 或授予权限；
+- NG-4：不记录 Prompt、模型文本、Tool 参数、ToolResult、Provider 原始响应、路径、凭据或环境变量；
+- NG-5：不改变 Event schema、Reducer、projection、SQLite migration、P2 恢复语义或 P3 授权语义；
+- NG-6：默认不记录 traceback；未来若需要本地 debug traceback，必须单独定义启用和脱敏边界。
+
+## 3. 场景与可观察行为
+
+### Scenario A：跟随一次正常 Run
+
+- FR-1：每条 Event 只能在对应 `EventStore.append` 成功返回后产生 `event.committed` record；
+- FR-2：record 包含 `run_id`、`event_id`、`event_type`、`sequence`、correlation/causation ID，以及可用的
+  `activity_id`、Event commit 耗时和 Activity 耗时；
+- FR-3：失败 Event 可以增加领域 `error_code`，但不能复制 Error message/details 或 Event payload。
+
+### Scenario B：Event 尚未建立时失败
+
+- FR-4：bootstrap 或 CLI 边界输出 `operation.failed` record；没有 RunId 时明确省略该字段，不伪造 ID；
+- FR-5：未知异常只输出 `internal_error` 和经过限制的异常类名，不输出 `str(error)`、`repr(error)` 或
+  traceback。
+
+### Scenario C：诊断输出不可用
+
+- FR-6：sink 抛错、序列化失败或 stderr 不可写时，原业务调用继续返回原来的结果或抛出原来的异常；
+- FR-7：诊断失败不追加 Event，不改变 projection，也不触发第二次模型或 Tool 调用。
+
+## 4. 对外入口与模块连接
+
+新增 BearAgent `DiagnosticRecord`、`DiagnosticSink` port、JSON Lines/Null adapter 和 EventStore
+decorator。`bootstrap.py` 仍是唯一 production composition root；`build_run_services` 与
+`build_run_query_service` 增加可选 sink 注入，省略时使用 stderr JSON Lines。
+
+CLI 命令和 JSON schema 不增加字段。结构化诊断只进入 stderr；`--json` stdout 仍只有一个 command
+result/error object。
+
+## 5. 状态与持久化
+
+Diagnostic record 只在当前进程中输出，不保存到数据库。即使某一行没有写出来、写入失败或后来被
+清理，Run 状态也不能因此变化。它不是 Event，不分配 Event sequence，也不进入 SQLite、Reducer、
+Checkpoint、Context 或 Artifact。Event 与 projection 的 transaction 边界不变。
+
+## 6. 失败、恢复与安全边界
+
+- Event 相关 record 必须 post-commit，不能把尚未提交的 Event 描述成事实；append 失败使用不同的
+  `event.append_failed` 名称；
+- sink 调用使用 fail-open 隔离，只捕获诊断 adapter 自身的普通异常；取消仍按原调用路径传播；
+- record 模型拒绝未知字段、无时区时间、负耗时和超长/非法标识符；JSON Line 还有独立 byte 上限；
+- record 没有 message、details、payload、path、request、response 或 stack 字段，从类型上阻止调用者
+  把任意内容塞入默认日志；
+- 日志不是恢复证据。进程退出后只相信已提交 Event；日志存在或缺失都不能改变 retry、reconcile、
+  `UNKNOWN` 或授权决定。
+
+## 7. 上线与回退
+
+不需要 migration 或数据回填。上线只增加 stderr 诊断；现有 stdout、Event 和数据库保持兼容。回退时
+可以撤销 composition wiring 和新增模块，已有数据库与 Event 不需要修改。若下游不希望接收 stderr，
+嵌入调用可以显式注入 `NullDiagnosticSink`。
+
+## 8. 验收标准与证据
+
+| AC | 可判断的结果 | 证据路径或命令 |
+|---|---|---|
+| AC-1 | 正常 Run 的已提交 Event 产生有序、安全的结构化 record，失败 Event 带有限错误码 | diagnostics unit/integration tests |
+| AC-2 | record 不包含 objective、模型文本、Tool 参数/结果、原始异常、路径或 secret | `tests/security/test_diagnostics.py` |
+| AC-3 | append 失败不产生 committed record；sink 失败不改变 append/query/Run 结果 | diagnostics unit/contract tests |
+| AC-4 | CLI stdout contract 不变，stderr record 可独立解析，安全 CLI Error 不泄漏原始异常 | CLI integration/security tests |
+| AC-5 | Event/Reducer/SQLite schema 与 migration 无变化，架构 import boundary 继续通过 | schema generators + architecture tests |
+| AC-6 | Ruff、format、Pyright、pytest、governance、docs links 和受影响站点构建通过 | 最终验证命令 |
+
+## 9. 文档影响
+
+| 表面 | 更新路径，或 `N/A` + 原因 |
+|---|---|
+| Engineering `docs/` | 本 Spec、ADR-0017、Plan、`docs/architecture/overview.md`、`docs/project/roadmap.md` |
+| Site beginner path | `site/src/content/docs/zh-cn/guides/cli.md`：说明 stdout/stderr 与日志不是恢复事实 |
+| Site developer docs | 新增 diagnostics 开发者页并从 development index/Agent Loop 页面连接 |
+| Site current status | `site/src/content/docs/zh-cn/project/status.md`：记录最小结构化诊断边界 |
+| Generated reference | N/A：不把 DiagnosticRecord 加入公开 domain/CLI schema contract |
+
+README 为 N/A：安装和最短 CLI 路径不变，这不是新的产品主能力。
+
+## 10. 尚未决定的问题
+
+- OQ-1：N/A。默认 sink、字段白名单、post-commit 和 P5 边界由 ADR-0017 决定；远程 exporter、sampling
+  和 traceback 需求必须由后续 Feature 重新评估。

--- a/docs/specs/F-0031-safe-structured-diagnostics.md
+++ b/docs/specs/F-0031-safe-structured-diagnostics.md
@@ -1,13 +1,13 @@
 ---
 title: "Feature: Safe structured operational diagnostics"
-status: accepted
+status: implemented
 spec_id: F-0031
 milestone: P1
 change_level: S2
 owner: CherryYang05
 created: 2026-09-02
-last_updated: 2026-09-02
-implemented_in: null
+last_updated: 2026-09-04
+implemented_in: 5d9da00
 related_adrs: [ADR-0002, ADR-0007, ADR-0013, ADR-0014, ADR-0017]
 ---
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -37,6 +37,7 @@ S1 使用精简范围：问题、目标/非目标、可观察行为、必要失�
   （本地开发、构建、预览、书籍化路线和 CLI 手册已完成；在线托管不在 Feature 范围内）
 - [F-0017：配置自己的模型服务，并用真实模型完成可检查文件任务](F-0017-configurable-model-providers-live-gate.md) — implemented
 - [F-0018：记录 Run 使用的可信执行契约，并展示进程中断前最后确认的事实](F-0018-p1-evidence-hardening.md) — implemented
+- [F-0031：安全输出结构化运行诊断，而不复制 Event 内容](F-0031-safe-structured-diagnostics.md) — accepted
 
 其余计划 Feature 见[路线图 Backlog](../project/roadmap.md#11-feature-backlog)。未创建 Spec 的名称只是
 计划范围，不能授权实现。

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -37,7 +37,7 @@ S1 使用精简范围：问题、目标/非目标、可观察行为、必要失�
   （本地开发、构建、预览、书籍化路线和 CLI 手册已完成；在线托管不在 Feature 范围内）
 - [F-0017：配置自己的模型服务，并用真实模型完成可检查文件任务](F-0017-configurable-model-providers-live-gate.md) — implemented
 - [F-0018：记录 Run 使用的可信执行契约，并展示进程中断前最后确认的事实](F-0018-p1-evidence-hardening.md) — implemented
-- [F-0031：安全输出结构化运行诊断，而不复制 Event 内容](F-0031-safe-structured-diagnostics.md) — accepted
+- [F-0031：安全输出结构化运行诊断，而不复制 Event 内容](F-0031-safe-structured-diagnostics.md) — implemented
 
 其余计划 Feature 见[路线图 Backlog](../project/roadmap.md#11-feature-backlog)。未创建 Spec 的名称只是
 计划范围，不能授权实现。

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -91,6 +91,7 @@ export default defineConfig({
             { label: 'workspace 只读 Tool', slug: 'development/workspace-read-tools' },
             { label: '原子输出与 Artifact', slug: 'development/atomic-output-artifacts' },
             { label: '有界 Agent Loop', slug: 'development/agent-loop' },
+            { label: '安全结构化运行诊断', slug: 'development/diagnostics' },
             { label: '生产 CLI 与查询', slug: 'development/run-cli' },
           ],
         },

--- a/site/src/content/docs/zh-cn/development/agent-loop.md
+++ b/site/src/content/docs/zh-cn/development/agent-loop.md
@@ -8,6 +8,8 @@ sourceRefs:
   - ADR-0013
   - F-0018
   - ADR-0016
+  - F-0031
+  - ADR-0017
 ---
 
 阅读 F-0016 时，先跟 `AgentLoop.run(RunInput)`，不要从某个模型或文件 adapter 倒推。Loop 只负责
@@ -96,3 +98,8 @@ retry 分支。
 
 F-0005 已用 production composition 和 CLI 调用这条 Loop；重启恢复、Approval 与 sandbox 仍未实现。
 修改 Loop 时，先证明没有旁路已有 port，再更新 Feature Spec、架构、学习页、开发者页和当前状态。
+
+F-0031 没有在 Loop 中增加 logger 分支。production bootstrap 只用 EventStore decorator 在 append 成功后
+输出固定 Event 元数据；sink 失败不能改变这里描述的任何保存或调用顺序。继续阅读
+[结构化诊断为什么不能成为第二套 Event](/zh-cn/development/diagnostics/)了解 Log、Event 和未来 Trace
+之间的边界。

--- a/site/src/content/docs/zh-cn/development/diagnostics.md
+++ b/site/src/content/docs/zh-cn/development/diagnostics.md
@@ -1,0 +1,97 @@
+---
+title: 为什么诊断日志不能决定 Run 发生了什么
+description: 沿着 DiagnosticRecord、EventStore decorator 和 bootstrap，理解 stderr 日志怎样帮助排错，以及为什么 Run 状态仍只看 Event。
+bearStatus: implemented
+sourceRefs:
+  - F-0031
+  - ADR-0017
+  - ADR-0002
+  - ADR-0013
+---
+
+运行一次文件任务时，你现在会在 stderr 看到一行一条的 JSON。它帮助开发者回答“哪个组件、哪项操作
+失败了”。但系统判断 Run 成功、失败或进行到哪里时，只读取 SQLite 中已经保存的 Event，不读取这些
+日志。
+
+```text
+EventStore.append(event)
+        |
+        +-- transaction 失败 --> event.append_failed（说明写入失败，Run 中没有这条 Event）
+        |
+        +-- transaction 成功 --> projection + Event 已提交
+                                   |
+                                   +--> event.committed（帮助排错；缺失不影响已保存 Event）
+```
+
+## 一条 record 里有什么
+
+`domain/diagnostics.py` 定义冻结的 `DiagnosticRecord`。它只允许：
+
+- schema version、UTC 时间、级别、组件和操作；
+- Run、Activity、Event、correlation 和 causation ID；
+- Event type、sequence、Event commit 耗时和当前进程内 Activity 耗时；
+- `ErrorCode` 和经过格式限制的异常类名。
+
+这个类型没有 `message`、`details`、`payload`、`path`、`request`、`response` 或 `stack` 字段。调用方
+因此不能顺手把 objective、模型回复、Tool 参数/结果、Provider body 或 `repr(error)` 塞进默认日志。
+JSON adapter 还限制单行最多 4 KiB。
+
+下面是一条形状示例，ID 会随 Run 改变：
+
+```json
+{"component":"event_store","event_type":"RunStarted","level":"info","name":"event.committed","operation":"event_append","operation_duration_ms":1,"run_id":"...","sequence":2,"schema_version":1}
+```
+
+需要完整执行内容时，使用 `bearagent run events RUN_ID --json`。那是显式读取本地 Event，不是可以随意
+转发的脱敏日志。
+
+## 代码怎样连接
+
+| 位置 | 责任 |
+|---|---|
+| `domain/diagnostics.py` | 字段封闭的不可变 record |
+| `ports/diagnostics.py` | sink protocol 与 fail-open `emit_safely` |
+| `adapters/diagnostics.py` | stderr JSON Lines、Null sink 和 EventStore decorator |
+| `bootstrap.py` | 选择默认 sink，装饰 production SQLite Store，记录组装/查询失败 |
+| `interfaces/cli/main.py` | 在 Error renderer 前记录有限 CLI operation failure |
+
+AgentLoop 没有 logger 分支。它仍只调用 EventStore port；production bootstrap 把 SQLite Store 包在
+diagnostic decorator 里。同一个 Store 实例继续交给 AgentLoop 和 RunQueryService，所以诊断接线没有
+产生第二条业务路径。
+
+## 为什么先保存 Event，再输出日志
+
+如果先打印 `RunSucceeded`，随后 SQLite transaction 回滚，日志会声称 Run 成功，但 EventStore 没有
+这条事实。decorator 因而必须等 delegate `append` 成功返回后才输出 `event.committed`。
+
+反过来，stderr 可能在 Event 提交后立刻故障，或者进程在输出前退出。这时日志会缺一行，但系统仍能
+从 SQLite 查到这条 Event。简单说：日志可以漏记已经保存的 Event，却不能用来补充数据库里不存在的
+Event。
+
+## 为什么日志写失败不能让 Run 失败
+
+代码中把这种处理称为 `fail-open`：`emit_safely` 会接住日志输出本身的普通异常。写 stderr、JSON
+序列化或测试 sink 失败都不会：
+
+- 回滚已经提交的 Event；
+- 把成功 Run 改成失败；
+- 触发第二次模型或 Tool 调用；
+- 给 Reducer、恢复或 Policy 增加输入。
+
+取消仍沿原业务调用传播；诊断层不把 `CancelledError` 改写成普通失败。
+
+## Log 和 Trace 的当前边界
+
+F-0031 可以用 started/terminal Event 对计算当前进程内的近似 Activity 耗时，但没有 span tree、sampling、
+remote collector 或跨进程 propagation。完整 Trace、OpenTelemetry exporter 和跨版本比较仍属于 P5。
+
+修改这条边界时，优先运行：
+
+```powershell
+uv run pytest tests/unit/test_diagnostics.py tests/security/test_diagnostics.py -q
+uv run pytest tests/integration/test_run_cli.py -q
+uv run python scripts/check_governance.py
+```
+
+重点不是“日志数量够不够多”，而是确认它只携带排错所需的最小字段，并且永远不能改变 Run 状态或
+补写 Event。

--- a/site/src/content/docs/zh-cn/development/index.md
+++ b/site/src/content/docs/zh-cn/development/index.md
@@ -10,6 +10,8 @@ sourceRefs:
   - F-0005
   - F-0017
   - F-0018
+  - F-0031
+  - ADR-0017
 ---
 
 开发者文档不复制 Spec，也不把每个目录重新列一遍。它负责回答三个问题：代码从哪里进入、关键
@@ -64,6 +66,7 @@ RunState。第三遍再读安全测试，确认你看到的是受测试约束的
 - [F-0007：workspace 只读 Tool](/zh-cn/development/workspace-read-tools/)——跨平台路径边界、list/read/search 和安全测试；
 - [F-0008：原子输出与 Artifact](/zh-cn/development/atomic-output-artifacts/)——同目录暂存、原子提交、结果元数据和故障窗口；
 - [F-0016/F-0018：有界 Agent Loop 与证据边界](/zh-cn/development/agent-loop/)——Context、RunCreated v4、contract fingerprint、串行调度和 K1-K6；
+- [F-0031：安全结构化运行诊断](/zh-cn/development/diagnostics/)——Event 写入数据库后输出有限日志，并保证日志失败不影响 Run；
 - [F-0005：生产 CLI 与查询](/zh-cn/development/run-cli/)——Run profile、composition root、inspect/events、JSON 契约和失败边界；
 - [Feature 完成时怎样更新文档](/zh-cn/development/feature-documentation/)——哪些事实写在 `docs/`，哪些解释写在站点；
 - [本地运行文档站](/zh-cn/guides/local-docs/)——安装、构建和检查 Starlight。

--- a/site/src/content/docs/zh-cn/guides/cli.md
+++ b/site/src/content/docs/zh-cn/guides/cli.md
@@ -9,6 +9,8 @@ sourceRefs:
   - ADR-0015
   - F-0018
   - ADR-0016
+  - F-0031
+  - ADR-0017
   - cli schema snapshot
 ---
 
@@ -201,9 +203,14 @@ uv run bearagent run "生成 outputs/report.md" --json `
   --database .\data\bearagent.db
 ```
 
-stdout 恰好是一个对象；进度和预分配 Run ID 仍在 stderr，不会破坏 JSON 管道。
+stdout 恰好是一个对象；进度、预分配 Run ID 和一行一条的结构化运行诊断都在 stderr，不会破坏 JSON
+管道。诊断只包含组件、操作、关联 ID、Event type/sequence、有限耗时和错误码，不复制 objective、
+模型文本、Tool 参数/结果或原始异常。
 version 1 的精确 JSON Schema 快照位于 `tests/contract/snapshots/cli_schemas.json`；脚本应按
 `schema_version` 解析，不要依赖 human 文本行。
+
+stderr 不是恢复记录。日志丢失或输出失败不会改变 Run；判断已经发生什么仍使用 `inspect/events`。
+完整 Event JSON 可能含敏感业务内容，不能与默认诊断日志混为一谈。
 
 ## 6. 查看一个 Run 的当前状态
 

--- a/site/src/content/docs/zh-cn/project/status.md
+++ b/site/src/content/docs/zh-cn/project/status.md
@@ -17,6 +17,8 @@ sourceRefs:
   - F-0017
   - F-0018
   - ADR-0016
+  - F-0031
+  - ADR-0017
 ---
 
 BearAgent 已有本地 `run/inspect/events` CLI。它用 config v1 与 RunProfile v2 显式选择
@@ -32,6 +34,7 @@ RunCreated v4 保存声明的 BearAgent/Policy/Tool contract identity，并完�
 | 能在本机运行一个真实模型文件任务吗？ | 能，需要有效 config、非零预算和受限 workspace |
 | 能查询任务做过什么吗？ | 能，用 `inspect` 看状态，用 `events` 看有序事实 |
 | 能知道 Run 使用了哪版 Tool/Policy 声明吗？ | 新 Run 可以；`inspect` 显示版本和 SHA-256，legacy Run 明确缺失 |
+| 能用结构化日志定位本机运行失败吗？ | 可以；stderr 提供固定字段诊断，但系统仍只根据 Event 判断 Run 状态 |
 | 程序中断后会自动继续吗？ | 不会，P2 尚未实现 |
 | 有用户 Approval 或真正的 sandbox 吗？ | 没有，P3 尚未实现 |
 | 文档站可以查看吗？ | 可以；在本地启动开发或生产预览，仓库不负责在线部署 |
@@ -70,6 +73,7 @@ P1 当前怎样操作见[命令行完整使用手册](/zh-cn/guides/cli/)；执�
 ## 当前明确不能做
 
 - SQLite 可以保存 Event 和 projection，但进程重启后不会自动继续 Run；
+- stderr diagnostics 不是持久 Event，也没有 OpenTelemetry、远程 collector、完整 span tree 或 traceback；
 - `inspect/events` 只能查看已提交事实，不能 resume、retry 或修复非终态 Run；
 - RunCreated v4 增加安全 Provider 选择与 contract fingerprint；其余 Activity 继续复用 v2 payload shape；
 - K4 即使文件已经 replace，terminal Event 缺失时仍只显示 RUNNING；当前不会 reconcile 或自动补成功；

--- a/site/src/content/docs/zh-cn/project/status.md
+++ b/site/src/content/docs/zh-cn/project/status.md
@@ -59,7 +59,8 @@ RunCreated v4 保存声明的 BearAgent/Policy/Tool contract identity，并完�
 
 ## P1 完成证据
 
-- 最终离线门禁通过 445 个测试、schema、链接、Starlight、sdist/wheel 与隔离 CLI smoke；
+- F-0017 关闭时的离线门禁通过 445 个测试；F-0031 的实现提交 `5d9da00` 在隔离工作树中通过
+  483 个测试、schema、114 个 Markdown 文件链接、46 页 Starlight 与 sdist/wheel 构建；
 - suite v1.1.1 使用确认的 Provider、model、pricing snapshot、commit 和费用上限；
 - 四个普通任务与安全 canary 通过 5/5；五个独立 SQLite 重开后 inspection/Event/Artifact 一致；
 - 总 usage 为 13,640 input、1,415 output tokens，报告费用为 2,324 microUSD；

--- a/src/bearagent/adapters/diagnostics.py
+++ b/src/bearagent/adapters/diagnostics.py
@@ -1,0 +1,251 @@
+"""Standard-library adapters for local structured diagnostics."""
+
+import json
+import re
+import sys
+import time
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import TextIO
+
+from bearagent.domain.diagnostics import DiagnosticLevel, DiagnosticRecord
+from bearagent.domain.errors import BearAgentError, ErrorCode, ErrorInfo
+from bearagent.domain.events import Event
+from bearagent.domain.ids import ActivityId, RunId
+from bearagent.domain.run_events import parse_run_event_payload
+from bearagent.domain.runs import RunState
+from bearagent.ports.diagnostics import DiagnosticSink, emit_safely
+from bearagent.ports.store import DEFAULT_EVENT_QUERY_LIMIT, EventStore
+
+MAX_DIAGNOSTIC_LINE_BYTES = 4_096
+_SAFE_EXCEPTION_TYPE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]{0,127}$")
+_ACTIVITY_STARTED_EVENTS = frozenset({"ModelCallStarted", "ToolCallStarted"})
+_ACTIVITY_TERMINAL_EVENTS = frozenset(
+    {"ModelCallCompleted", "ModelCallFailed", "ToolCallCompleted", "ToolCallFailed"}
+)
+
+
+class NullDiagnosticSink:
+    """Explicitly discard diagnostics for embedding and deterministic tests."""
+
+    def emit(self, record: DiagnosticRecord) -> None:
+        del record
+
+
+class JsonLinesDiagnosticSink:
+    """Write one bounded JSON object per line to stderr by default."""
+
+    def __init__(self, stream: TextIO | None = None) -> None:
+        self._stream = stream
+
+    def emit(self, record: DiagnosticRecord) -> None:
+        line = json.dumps(
+            record.model_dump(mode="json", exclude_none=True),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        if len(line.encode("utf-8")) > MAX_DIAGNOSTIC_LINE_BYTES:
+            raise ValueError("diagnostic line exceeds the byte limit")
+        stream = self._stream if self._stream is not None else sys.stderr
+        stream.write(f"{line}\n")
+        stream.flush()
+
+
+class DiagnosticEventStore:
+    """Decorate an EventStore with post-commit metadata-only diagnostics."""
+
+    def __init__(
+        self,
+        delegate: EventStore,
+        sink: DiagnosticSink,
+        *,
+        clock: Callable[[], datetime] | None = None,
+        monotonic_ns: Callable[[], int] | None = None,
+    ) -> None:
+        self._delegate = delegate
+        self._sink = sink
+        self._clock = clock or _utc_now
+        self._monotonic_ns = monotonic_ns or time.perf_counter_ns
+        self._activity_started_at: dict[ActivityId, int] = {}
+
+    async def append(self, event: Event) -> RunState:
+        started_at = self._monotonic_ns()
+        try:
+            state = await self._delegate.append(event)
+        except Exception as error:
+            emit_safely(
+                self._sink,
+                operation_failure_record(
+                    component="event_store",
+                    operation="event_append",
+                    error=error,
+                    emitted_at=self._clock(),
+                    run_id=event.run_id,
+                    event=event,
+                    operation_duration_ms=_elapsed_ms(started_at, self._monotonic_ns()),
+                    name="event.append_failed",
+                ),
+            )
+            raise
+
+        finished_at = self._monotonic_ns()
+        activity_id, error_info = _event_diagnostic_fields(event)
+        activity_duration_ms = self._activity_duration(
+            event,
+            activity_id=activity_id,
+            finished_at=finished_at,
+        )
+        emit_safely(
+            self._sink,
+            DiagnosticRecord(
+                emitted_at=self._clock(),
+                level=(DiagnosticLevel.ERROR if error_info is not None else DiagnosticLevel.INFO),
+                name="event.committed",
+                component="event_store",
+                operation="event_append",
+                run_id=event.run_id,
+                activity_id=activity_id,
+                event_id=event.event_id,
+                event_type=event.event_type,
+                sequence=event.sequence,
+                correlation_id=event.correlation_id,
+                causation_id=event.causation_id,
+                operation_duration_ms=_elapsed_ms(started_at, finished_at),
+                activity_duration_ms=activity_duration_ms,
+                error_code=error_info.code if error_info is not None else None,
+            ),
+        )
+        return state
+
+    async def list_events(
+        self,
+        run_id: RunId,
+        *,
+        after_sequence: int = 0,
+        limit: int = DEFAULT_EVENT_QUERY_LIMIT,
+    ) -> tuple[Event, ...]:
+        started_at = self._monotonic_ns()
+        try:
+            return await self._delegate.list_events(
+                run_id,
+                after_sequence=after_sequence,
+                limit=limit,
+            )
+        except Exception as error:
+            emit_safely(
+                self._sink,
+                operation_failure_record(
+                    component="event_store",
+                    operation="event_list",
+                    error=error,
+                    emitted_at=self._clock(),
+                    run_id=run_id,
+                    operation_duration_ms=_elapsed_ms(started_at, self._monotonic_ns()),
+                ),
+            )
+            raise
+
+    async def get_run(self, run_id: RunId) -> RunState | None:
+        started_at = self._monotonic_ns()
+        try:
+            return await self._delegate.get_run(run_id)
+        except Exception as error:
+            emit_safely(
+                self._sink,
+                operation_failure_record(
+                    component="event_store",
+                    operation="run_get",
+                    error=error,
+                    emitted_at=self._clock(),
+                    run_id=run_id,
+                    operation_duration_ms=_elapsed_ms(started_at, self._monotonic_ns()),
+                ),
+            )
+            raise
+
+    def _activity_duration(
+        self,
+        event: Event,
+        *,
+        activity_id: ActivityId | None,
+        finished_at: int,
+    ) -> int | None:
+        if activity_id is None:
+            return None
+        if event.event_type in _ACTIVITY_STARTED_EVENTS:
+            self._activity_started_at[activity_id] = finished_at
+            return None
+        if event.event_type not in _ACTIVITY_TERMINAL_EVENTS:
+            return None
+        started_at = self._activity_started_at.pop(activity_id, None)
+        if started_at is None:
+            return None
+        return _elapsed_ms(started_at, finished_at)
+
+
+def operation_failure_record(
+    *,
+    component: str,
+    operation: str,
+    error: BaseException,
+    error_info: ErrorInfo | None = None,
+    emitted_at: datetime | None = None,
+    run_id: RunId | None = None,
+    event: Event | None = None,
+    operation_duration_ms: int | None = None,
+    name: str = "operation.failed",
+) -> DiagnosticRecord:
+    """Build a failure signal without reading exception text or arbitrary details."""
+
+    safe_error_info = (
+        error_info
+        if error_info is not None
+        else error.info
+        if isinstance(error, BearAgentError)
+        else None
+    )
+    return DiagnosticRecord(
+        emitted_at=emitted_at or _utc_now(),
+        level=DiagnosticLevel.ERROR,
+        name=name,
+        component=component,
+        operation=operation,
+        run_id=run_id,
+        event_id=event.event_id if event is not None else None,
+        event_type=event.event_type if event is not None else None,
+        sequence=event.sequence if event is not None else None,
+        correlation_id=event.correlation_id if event is not None else None,
+        causation_id=event.causation_id if event is not None else None,
+        operation_duration_ms=operation_duration_ms,
+        error_code=(
+            safe_error_info.code if safe_error_info is not None else ErrorCode.INTERNAL_ERROR
+        ),
+        exception_type=_safe_exception_type(error),
+    )
+
+
+def _event_diagnostic_fields(event: Event) -> tuple[ActivityId | None, ErrorInfo | None]:
+    try:
+        payload = parse_run_event_payload(event)
+    except (KeyError, ValueError):
+        return None, None
+    activity_id = getattr(payload, "activity_id", None)
+    error_info = getattr(payload, "error", None)
+    return (
+        activity_id if isinstance(activity_id, ActivityId) else None,
+        error_info if isinstance(error_info, ErrorInfo) else None,
+    )
+
+
+def _safe_exception_type(error: BaseException) -> str:
+    name = type(error).__name__
+    return name if _SAFE_EXCEPTION_TYPE.fullmatch(name) else "Exception"
+
+
+def _elapsed_ms(started_at: int, finished_at: int) -> int:
+    return max(0, (finished_at - started_at) // 1_000_000)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)

--- a/src/bearagent/bootstrap.py
+++ b/src/bearagent/bootstrap.py
@@ -11,6 +11,11 @@ from typing import Annotated
 from pydantic import Field, TypeAdapter, ValidationError
 
 from bearagent import package_version
+from bearagent.adapters.diagnostics import (
+    DiagnosticEventStore,
+    JsonLinesDiagnosticSink,
+    operation_failure_record,
+)
 from bearagent.adapters.model import (
     AnthropicMessagesProvider,
     OpenAIChatCompletionsProvider,
@@ -24,6 +29,7 @@ from bearagent.domain.agent import AgentConfig, ModelPricing, RunProfile, RunPro
 from bearagent.domain.errors import BearAgentError, ErrorCategory, ErrorCode, ErrorInfo
 from bearagent.domain.ids import IdGenerator
 from bearagent.domain.providers import ModelProtocol, ProviderSelection
+from bearagent.ports.diagnostics import DiagnosticSink, emit_safely
 from bearagent.ports.model import ModelProvider
 from bearagent.runtime.fingerprints import build_run_fingerprint
 from bearagent.runtime.policy import FixedToolPolicy
@@ -114,8 +120,44 @@ async def build_run_services(
     provider_catalog: ProviderCatalog | None = None,
     model_provider: ModelProvider | None = None,
     id_generator: IdGenerator | None = None,
+    diagnostic_sink: DiagnosticSink | None = None,
 ) -> RunServices:
     """Validate inputs, initialize SQLite, and assemble the production Run graph."""
+    sink = diagnostic_sink if diagnostic_sink is not None else JsonLinesDiagnosticSink()
+    try:
+        return await _build_run_services(
+            profile_path=profile_path,
+            config_path=config_path,
+            workspace_path=workspace_path,
+            database_path=database_path,
+            provider_catalog=provider_catalog,
+            model_provider=model_provider,
+            id_generator=id_generator,
+            diagnostic_sink=sink,
+        )
+    except Exception as error:
+        emit_safely(
+            sink,
+            operation_failure_record(
+                component="bootstrap",
+                operation="build_run_services",
+                error=error,
+            ),
+        )
+        raise
+
+
+async def _build_run_services(
+    *,
+    profile_path: str | os.PathLike[str],
+    config_path: str | os.PathLike[str],
+    workspace_path: str | os.PathLike[str],
+    database_path: str | os.PathLike[str],
+    provider_catalog: ProviderCatalog | None,
+    model_provider: ModelProvider | None,
+    id_generator: IdGenerator | None,
+    diagnostic_sink: DiagnosticSink,
+) -> RunServices:
     profile = load_run_profile(profile_path)
     provider_selection, provider_config = _resolve_provider_selection(
         profile,
@@ -151,8 +193,9 @@ async def build_run_services(
             cause=error,
         ) from error
 
-    store = SqliteEventStore(Path(database_path))
-    await store.initialize()
+    sqlite_store = SqliteEventStore(Path(database_path))
+    await sqlite_store.initialize()
+    store = DiagnosticEventStore(sqlite_store, diagnostic_sink)
     return RunServices(
         profile=profile,
         agent_config=agent_config,
@@ -267,23 +310,44 @@ def _build_selected_model_provider(
 
 async def build_run_query_service(
     database_path: str | os.PathLike[str],
+    *,
+    diagnostic_sink: DiagnosticSink | None = None,
 ) -> RunQueryService:
     """Open an existing ordinary database without creating a missing one."""
+    sink = diagnostic_sink if diagnostic_sink is not None else JsonLinesDiagnosticSink()
     try:
         path = await asyncio.to_thread(_require_existing_database, database_path)
-    except (OSError, ValueError) as error:
-        raise BootstrapError(
+        sqlite_store = SqliteEventStore(path)
+        await sqlite_store.initialize()
+        return RunQueryService(DiagnosticEventStore(sqlite_store, sink))
+    except BearAgentError as error:
+        emit_safely(
+            sink,
+            operation_failure_record(
+                component="bootstrap",
+                operation="build_query_service",
+                error=error,
+            ),
+        )
+        raise
+    except Exception as error:
+        safe_error = BootstrapError(
             ErrorInfo(
                 category=ErrorCategory.PERSISTENCE,
                 code=ErrorCode.PERSISTENCE_ERROR,
                 message="Run database is missing or invalid.",
             ),
             cause=error,
-        ) from error
-
-    store = SqliteEventStore(path)
-    await store.initialize()
-    return RunQueryService(store)
+        )
+        emit_safely(
+            sink,
+            operation_failure_record(
+                component="bootstrap",
+                operation="build_query_service",
+                error=safe_error,
+            ),
+        )
+        raise safe_error from error
 
 
 def _is_link_like(path: Path, path_stat: os.stat_result) -> bool:

--- a/src/bearagent/domain/diagnostics.py
+++ b/src/bearagent/domain/diagnostics.py
@@ -1,0 +1,57 @@
+"""Typed diagnostics that help troubleshooting without deciding Run state."""
+
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import Field, field_validator
+
+from bearagent.domain._base import DomainModel
+from bearagent.domain.errors import ErrorCode
+from bearagent.domain.events import EVENT_TYPE_PATTERN
+from bearagent.domain.ids import (
+    ActivityId,
+    CausationId,
+    CorrelationId,
+    EventId,
+    RunId,
+)
+
+DIAGNOSTIC_NAME_PATTERN = r"^[a-z][a-z0-9_.-]{0,63}$"
+EXCEPTION_TYPE_PATTERN = r"^[A-Za-z_][A-Za-z0-9_.]{0,127}$"
+
+
+class DiagnosticLevel(StrEnum):
+    """Small fixed severity vocabulary for local operational signals."""
+
+    INFO = "info"
+    ERROR = "error"
+
+
+class DiagnosticRecord(DomainModel):
+    """A bounded signal that can never carry Event bodies or arbitrary text."""
+
+    schema_version: Literal[1] = 1
+    emitted_at: datetime
+    level: DiagnosticLevel
+    name: str = Field(pattern=DIAGNOSTIC_NAME_PATTERN)
+    component: str = Field(pattern=DIAGNOSTIC_NAME_PATTERN)
+    operation: str = Field(pattern=DIAGNOSTIC_NAME_PATTERN)
+    run_id: RunId | None = None
+    activity_id: ActivityId | None = None
+    event_id: EventId | None = None
+    event_type: str | None = Field(default=None, pattern=EVENT_TYPE_PATTERN)
+    sequence: int | None = Field(default=None, ge=1, strict=True)
+    correlation_id: CorrelationId | None = None
+    causation_id: CausationId | None = None
+    operation_duration_ms: int | None = Field(default=None, ge=0, strict=True)
+    activity_duration_ms: int | None = Field(default=None, ge=0, strict=True)
+    error_code: ErrorCode | None = None
+    exception_type: str | None = Field(default=None, pattern=EXCEPTION_TYPE_PATTERN)
+
+    @field_validator("emitted_at")
+    @classmethod
+    def require_aware_utc_time(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("emitted_at must include a timezone")
+        return value.astimezone(UTC)

--- a/src/bearagent/interfaces/cli/main.py
+++ b/src/bearagent/interfaces/cli/main.py
@@ -13,6 +13,7 @@ from typer import _click
 from typer.core import TyperGroup
 
 from bearagent import package_version
+from bearagent.adapters.diagnostics import JsonLinesDiagnosticSink, operation_failure_record
 from bearagent.bootstrap import build_run_query_service, build_run_services
 from bearagent.domain.agent import MAX_OBJECTIVE_CHARS, RunInput
 from bearagent.domain.errors import BearAgentError, ErrorCategory, ErrorCode, ErrorInfo
@@ -31,6 +32,7 @@ from bearagent.interfaces.cli.renderers import (
     render_json,
     render_run,
 )
+from bearagent.ports.diagnostics import emit_safely
 
 DEFAULT_PROFILE_PATH = Path("data/p1-run-profile.json")
 DEFAULT_CONFIG_PATH = Path("data/config.json")
@@ -303,6 +305,15 @@ def _exit_with_error(
     json_output: bool,
 ) -> NoReturn:
     info = _safe_error_info(error)
+    emit_safely(
+        JsonLinesDiagnosticSink(),
+        operation_failure_record(
+            component="cli",
+            operation=command,
+            error=error,
+            error_info=info,
+        ),
+    )
     output = CommandErrorOutput(command=command, error=info)
     typer.echo(render_json(output) if json_output else f"Error: {render_error(info)}")
     raise typer.Exit(code=1)

--- a/src/bearagent/ports/diagnostics.py
+++ b/src/bearagent/ports/diagnostics.py
@@ -1,0 +1,21 @@
+"""Port for bounded diagnostics whose loss cannot affect a Run."""
+
+from typing import Protocol
+
+from bearagent.domain.diagnostics import DiagnosticRecord
+
+
+class DiagnosticSink(Protocol):
+    """Accept one already-safe diagnostic record."""
+
+    def emit(self, record: DiagnosticRecord) -> None: ...
+
+
+def emit_safely(sink: DiagnosticSink, record: DiagnosticRecord) -> None:
+    """Keep diagnostics adapter failures outside Runtime behavior."""
+
+    try:
+        sink.emit(record)
+    except Exception:
+        # A diagnostic signal is never a Run fact or a reason to retry work.
+        return

--- a/tests/security/test_diagnostics.py
+++ b/tests/security/test_diagnostics.py
@@ -1,0 +1,81 @@
+import asyncio
+
+from tests.agent_loop_fixtures import (
+    agent_run_input,
+    model_completed,
+    read_tool_spec,
+    run_fingerprint,
+    tool_executor,
+)
+
+from bearagent.adapters.diagnostics import DiagnosticEventStore
+from bearagent.adapters.testing import FakeTool, InMemoryEventStore, ScriptedFakeModelProvider
+from bearagent.application import AgentLoop
+from bearagent.domain.diagnostics import DiagnosticRecord
+from bearagent.domain.ids import ToolCallId
+from bearagent.domain.model import (
+    ModelCompleted,
+    ModelFinishReason,
+    ModelTextDelta,
+    ModelToolCall,
+    ModelUsage,
+)
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self.records: list[DiagnosticRecord] = []
+
+    def emit(self, record: DiagnosticRecord) -> None:
+        self.records.append(record)
+
+
+def test_execution_diagnostics_do_not_copy_event_payload_content() -> None:
+    objective_secret = "objective-secret-marker"
+    argument_secret = "argument-secret-marker"
+    result_secret = "result-secret-marker"
+    model_secret = "model-secret-marker"
+    call_id = ToolCallId.new()
+    provider = ScriptedFakeModelProvider(
+        [
+            (
+                ModelToolCall(
+                    tool_call_id=call_id,
+                    provider_call_id="call-1",
+                    name="workspace.read",
+                    arguments={"path": argument_secret},
+                ),
+                model_completed(ModelFinishReason.TOOL_CALLS),
+            ),
+            (
+                ModelTextDelta(text=model_secret),
+                ModelCompleted(
+                    provider_request_id="response-2",
+                    model="test-model",
+                    finish_reason=ModelFinishReason.STOP,
+                    usage=ModelUsage(input_tokens=3, output_tokens=4),
+                ),
+            ),
+        ]
+    )
+    sink = RecordingSink()
+    loop = AgentLoop(
+        model_provider=provider,
+        event_store=DiagnosticEventStore(InMemoryEventStore(), sink),
+        tool_executor=tool_executor(FakeTool(read_tool_spec(), data={"content": result_secret})),
+        run_fingerprint=run_fingerprint(),
+    )
+    run_input = agent_run_input().model_copy(update={"objective": objective_secret})
+
+    result = asyncio.run(loop.run(run_input))
+
+    serialized = "\n".join(record.model_dump_json() for record in sink.records)
+    assert result.final_text == model_secret
+    assert sink.records
+    assert objective_secret not in serialized
+    assert argument_secret not in serialized
+    assert result_secret not in serialized
+    assert model_secret not in serialized
+    assert '"payload"' not in serialized
+    assert '"message"' not in serialized
+    assert '"details"' not in serialized

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -21,9 +21,18 @@ from bearagent.bootstrap import (
     load_run_profile,
 )
 from bearagent.domain.agent import RunProfile
+from bearagent.domain.diagnostics import DiagnosticRecord
 from bearagent.domain.errors import ErrorCode
 from bearagent.domain.ids import RunId
 from bearagent.domain.model import ModelFinishReason, ModelTextDelta
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self.records: list[DiagnosticRecord] = []
+
+    def emit(self, record: DiagnosticRecord) -> None:
+        self.records.append(record)
 
 
 def _write_profile(path: Path, **extra: object) -> RunProfile:
@@ -123,11 +132,45 @@ def test_build_run_services_uses_injected_provider_and_one_sqlite_store(
     assert captured.value.info.code is ErrorCode.RUN_NOT_FOUND
 
 
+def test_build_run_services_wires_the_injected_diagnostic_sink(tmp_path: Path) -> None:
+    profile_path = tmp_path / "profile.json"
+    _write_profile(profile_path)
+    sink = RecordingSink()
+    provider = FakeModelProvider(
+        (
+            ModelTextDelta(text="done"),
+            model_completed(ModelFinishReason.STOP),
+        )
+    )
+    services = asyncio.run(
+        build_run_services(
+            profile_path=profile_path,
+            workspace_path=tmp_path,
+            database_path=tmp_path / "events.db",
+            model_provider=provider,
+            diagnostic_sink=sink,
+        )
+    )
+
+    result = asyncio.run(services.agent_loop.run(agent_run_input()))
+
+    assert result.state.last_sequence == len(sink.records)
+    assert [record.sequence for record in sink.records] == list(
+        range(1, result.state.last_sequence + 1)
+    )
+    assert all(record.name == "event.committed" for record in sink.records)
+
+
 def test_query_bootstrap_does_not_create_a_missing_database(tmp_path: Path) -> None:
     database_path = tmp_path / "missing" / "bearagent.db"
+    sink = RecordingSink()
 
     with pytest.raises(BootstrapError) as captured:
-        asyncio.run(build_run_query_service(database_path))
+        asyncio.run(build_run_query_service(database_path, diagnostic_sink=sink))
 
     assert captured.value.info.code is ErrorCode.PERSISTENCE_ERROR
     assert not database_path.exists()
+    assert len(sink.records) == 1
+    assert sink.records[0].component == "bootstrap"
+    assert sink.records[0].operation == "build_query_service"
+    assert sink.records[0].error_code is ErrorCode.PERSISTENCE_ERROR

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -54,3 +54,18 @@ def test_doctor_json_has_stable_non_sensitive_shape(monkeypatch: pytest.MonkeyPa
 def test_doctor_report_rejects_unsupported_python(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "version_info", (3, 13, 0))
     assert build_doctor_report()["status"] == "error"
+
+
+def test_cli_error_keeps_stdout_contract_and_emits_safe_structured_stderr() -> None:
+    result = runner.invoke(app, ["run", "--json", "   "])
+
+    assert result.exit_code == 1
+    stdout = json.loads(result.stdout)
+    stderr = json.loads(result.stderr)
+    assert stdout["command"] == "run"
+    assert stdout["error"]["code"] == "invalid_input"
+    assert stderr["name"] == "operation.failed"
+    assert stderr["component"] == "cli"
+    assert stderr["operation"] == "run"
+    assert stderr["error_code"] == "invalid_input"
+    assert "objective is invalid" not in result.stderr

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -1,0 +1,157 @@
+import asyncio
+import json
+from datetime import UTC, datetime
+from io import StringIO
+
+import pytest
+from pydantic import ValidationError
+from tests.store_fixtures import failed_run_event, run_created_event, successful_run_events
+
+from bearagent.adapters.diagnostics import (
+    DiagnosticEventStore,
+    JsonLinesDiagnosticSink,
+    operation_failure_record,
+)
+from bearagent.adapters.testing import EventSequenceError, InMemoryEventStore
+from bearagent.domain.diagnostics import DiagnosticLevel, DiagnosticRecord
+from bearagent.domain.errors import ErrorCode
+from bearagent.domain.ids import RunId
+from bearagent.ports.diagnostics import emit_safely
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self.records: list[DiagnosticRecord] = []
+
+    def emit(self, record: DiagnosticRecord) -> None:
+        self.records.append(record)
+
+
+class FailingSink:
+    def emit(self, record: DiagnosticRecord) -> None:
+        del record
+        raise OSError("diagnostic sink is unavailable")
+
+
+def test_diagnostic_record_is_frozen_and_rejects_arbitrary_text_fields() -> None:
+    record = DiagnosticRecord(
+        emitted_at=datetime(2026, 9, 2, tzinfo=UTC),
+        level=DiagnosticLevel.INFO,
+        name="event.committed",
+        component="event_store",
+        operation="event_append",
+    )
+
+    with pytest.raises(ValidationError):
+        DiagnosticRecord.model_validate(
+            {
+                **record.model_dump(mode="python"),
+                "message": "arbitrary content must not fit the schema",
+            }
+        )
+    with pytest.raises(ValidationError):
+        record.level = DiagnosticLevel.ERROR  # type: ignore[misc]
+
+
+def test_json_lines_sink_serializes_only_the_bounded_record() -> None:
+    raw_secret = "raw-exception-secret"
+    stream = StringIO()
+    sink = JsonLinesDiagnosticSink(stream)
+
+    sink.emit(
+        operation_failure_record(
+            component="bootstrap",
+            operation="build_run_services",
+            error=RuntimeError(raw_secret),
+            emitted_at=datetime(2026, 9, 2, tzinfo=UTC),
+        )
+    )
+
+    payload = json.loads(stream.getvalue())
+    assert payload == {
+        "component": "bootstrap",
+        "emitted_at": "2026-09-02T00:00:00Z",
+        "error_code": "internal_error",
+        "exception_type": "RuntimeError",
+        "level": "error",
+        "name": "operation.failed",
+        "operation": "build_run_services",
+        "schema_version": 1,
+    }
+    assert raw_secret not in stream.getvalue()
+
+
+def test_diagnostic_event_store_emits_only_after_successful_append() -> None:
+    run_id = RunId.new()
+    event = run_created_event(run_id)
+    sink = RecordingSink()
+    store = DiagnosticEventStore(InMemoryEventStore(), sink)
+
+    state = asyncio.run(store.append(event))
+
+    assert state.run_id == run_id
+    assert len(sink.records) == 1
+    committed = sink.records[0]
+    assert committed.name == "event.committed"
+    assert committed.run_id == run_id
+    assert committed.event_id == event.event_id
+    assert committed.event_type == "RunCreated"
+    assert committed.sequence == 1
+    assert committed.operation_duration_ms is not None
+
+    with pytest.raises(EventSequenceError):
+        asyncio.run(store.append(event))
+
+    assert [record.name for record in sink.records] == [
+        "event.committed",
+        "event.append_failed",
+    ]
+    assert sink.records[-1].error_code is ErrorCode.PERSISTENCE_ERROR
+
+
+def test_diagnostic_event_store_correlates_activity_duration_and_safe_error_code() -> None:
+    sink = RecordingSink()
+    ticks = iter(range(0, 100_000_000, 1_000_000))
+    store = DiagnosticEventStore(
+        InMemoryEventStore(),
+        sink,
+        monotonic_ns=lambda: next(ticks),
+    )
+    events = successful_run_events()[:5]
+
+    for event in events:
+        asyncio.run(store.append(event))
+
+    terminal = sink.records[-1]
+    assert terminal.event_type == "ModelCallCompleted"
+    assert terminal.activity_id is not None
+    assert terminal.activity_duration_ms is not None
+
+    failed = failed_run_event(events[0].run_id, sequence=6, message="private failure body")
+    asyncio.run(store.append(failed))
+    failure_record = sink.records[-1]
+    assert failure_record.level is DiagnosticLevel.ERROR
+    assert failure_record.error_code is ErrorCode.INTERNAL_ERROR
+    assert "private failure body" not in failure_record.model_dump_json()
+
+
+def test_failing_sink_does_not_change_event_or_error_behavior() -> None:
+    run_id = RunId.new()
+    event = run_created_event(run_id)
+    store = DiagnosticEventStore(InMemoryEventStore(), FailingSink())
+
+    state = asyncio.run(store.append(event))
+
+    assert state.run_id == run_id
+    with pytest.raises(EventSequenceError):
+        asyncio.run(store.append(event))
+
+
+def test_emit_safely_contains_sink_failure() -> None:
+    record = operation_failure_record(
+        component="cli",
+        operation="run",
+        error=RuntimeError("not logged"),
+    )
+
+    emit_safely(FailingSink(), record)


### PR DESCRIPTION
## Summary

- Add a bounded `DiagnosticRecord`, sink port, stderr JSON Lines adapter, and EventStore decorator that emits metadata only after a successful Event commit.
- Add safe bootstrap, CLI, append, and query failure diagnostics without copying objectives, model text, Tool arguments/results, paths, exception messages, or Event payloads.
- Keep Event as the only source used to determine Run state; diagnostic output may fail or be absent without changing execution, persistence, recovery, or retry behavior.

This is a dependency PR based on `codex/F-0018-p1-evidence-hardening`, because F-0031 was implemented against F-0018's RunCreated v4 and execution-evidence contracts. The PR diff intentionally excludes the separate, uncommitted F-0018 audit changes still present in the local worktree.

## Change governance

- Classification: `S2`
- Feature Spec: `F-0031`
- ADR: `ADR-0017`
- Plan: `PLAN-F-0031`

## Validation

- [x] Relevant unit, integration, and security tests; full suite: 483 passed
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pyright`
- [x] `uv run pytest`
- [x] `uv run python scripts/check_docs.py` (114 Markdown files)
- [x] `uv run python scripts/check_governance.py` (14 Specs, 13 Plans, 17 ADRs)
- [x] `npm run build --prefix=site` (46 pages)
- [x] Domain, CLI, and runtime-configuration schema generators produced no diff
- [x] sdist and wheel built; all three diagnostics modules are packaged

## Documentation impact

- Engineering `docs/`: `docs/specs/F-0031-safe-structured-diagnostics.md`, `docs/adr/ADR-0017-event-ledger-with-best-effort-ops-diagnostics.md`, `docs/plans/PLAN-F-0031-safe-structured-diagnostics.md`, `docs/architecture/overview.md`, `docs/project/roadmap.md`
- Site beginner learning path: `N/A - the feature changes developer troubleshooting behavior, not the beginner execution walkthrough`
- Site developer documentation: `site/src/content/docs/zh-cn/development/diagnostics.md`, `site/src/content/docs/zh-cn/development/agent-loop.md`
- Site current status or milestone summary: `site/src/content/docs/zh-cn/project/status.md`
- Generated reference: `N/A - diagnostic records are not a public Event, CLI stdout, or runtime-configuration schema`

- [x] Every surface above has either an updated path or a concrete `N/A` reason
- [x] Content distinguishes Event facts, current local logs, future Trace/OpenTelemetry work, and recovery plans
- [x] Changed prose was read in context and rewritten in behavior-first language
- [x] External references are comparison inputs only and do not become BearAgent implementation claims
