### PR TITLE
feat(runtime): harden P1 execution evidence

### DIFF
--- a/docs/adr/ADR-0016-run-contract-fingerprint-committed-crash-facts.md
+++ b/docs/adr/ADR-0016-run-contract-fingerprint-committed-crash-facts.md
@@ -62,7 +62,8 @@ ToolSpec/Policy 静态 contract 使用 canonical JSON + SHA-256；Run 创建时�
 5. Composition root 使用声明的 BearAgent package version、Registry snapshot 与 Policy fingerprint 构造
    `RunFingerprint`，再作为必需 BearAgent 类型注入 AgentLoop。Application 不读取包元数据或具体 adapter。
 6. 新 Run 统一写 Event schema v4。`RunCreatedPayloadV4` 保存 fingerprint 和可选 Provider selection；其他
-   v4 payload 继续复用 v2 的 Provider-neutral shape。v1/v2/v3 永久可读。
+   v4 payload 继续复用 v2 的 Provider-neutral shape。依赖这个 shape 的跨 Event 不变量按解析后的 payload
+   类型执行，不能因为新增 schema version 而失效。v1/v2/v3 永久可读。
 7. fingerprint 只存在于 `RunCreated` Event。`RunState`/SQLite projection 不增加字段；inspect 从 committed
    Event 提取，legacy Run 返回 `null`，绝不按当前 Runtime 配置反推。
 8. `ErrorInfo.retryable` 是来源 hint；`ToolRetrySafety` 是粗粒度 contract hint。二者都不是

--- a/docs/adr/ADR-0016-run-contract-fingerprint-committed-crash-facts.md
+++ b/docs/adr/ADR-0016-run-contract-fingerprint-committed-crash-facts.md
@@ -1,0 +1,111 @@
+---
+title: "ADR-0016: persist trusted Run contract identity and report only committed crash facts"
+status: accepted
+date: 2026-08-28
+decision_owners: [CherryYang05]
+supersedes: null
+superseded_by: null
+---
+
+# ADR-0016：Run 创建时保存可信契约身份，进程中断后只报告已提交事实
+
+## 要解决的问题
+
+P1 已经保存一次调用的请求、PolicyDecision 和结果，却没有保存 Run 启动时注册的 Tool/Policy contract
+identity。同名 Tool 或固定 Policy 以后改变时，历史 Event 仍可读取，但读者无法判断当时使用了哪套声明。
+
+同时，现有异常注入测试能证明 Loop 不重试，却不能证明进程 hard exit 后 SQLite、projection、workspace 和
+CLI 对“最后确认知道什么”保持一致。如果为方便查询把 fingerprint 放进 projection，或让 crash 测试根据
+文件现状补写成功，都会产生第二份事实来源并提前进入 P2 recovery。
+
+## 选择时最看重什么
+
+- 可维护性：复用 Domain Value Object、现有 ToolRegistry/Policy 和 Event schema，不建立第二套配置或 registry；
+- 恢复语义：P1 只保存 identity 与 committed boundary，不根据 hint/目标状态决定下一步；
+- 安全：fingerprint 只能来自可信静态注册信息，不能承载 secret、路径、Prompt、输出或权限 token；
+- 复杂度/交付时间：使用标准库 JSON/SHA-256 和测试 wrapper，不引入依赖、生产 fault framework 或 DB 表；
+- 兼容与迁移：旧 Event/SQLite 只读语义不变，新事实使用 v4 payload JSON。
+
+## 比较过的方案
+
+### 方案 A：只保存包版本和 Tool 名称
+
+字段少，但同一版本内 Tool schema、资源上限、Policy allowlist 或 prepare contract 不同仍无法区分；包版本
+也不能精确表达每个声明内容。
+
+### 方案 B：在每个 Tool Event 保存完整 ToolSpec 和 Policy 配置
+
+查询直接，但重复大量 JSON；单次 Event 与 Run 启动 contract 可能分叉；未来动态 Approval 也容易被误塞
+进静态 identity。
+
+### 方案 C：RunCreated 保存版本化 fingerprint，Event 保持事实来源
+
+ToolSpec/Policy 静态 contract 使用 canonical JSON + SHA-256；Run 创建时一次保存。Query 从首个 Event
+读取，legacy Run 明确缺失。hash 只标识声明，不声称包含全部实现。
+
+### 方案 D：建立 fingerprint/projection 数据表
+
+读取快，但引入 migration 和新的事实真相；表与 Event 分叉后难以判断哪份可信，收益不抵复杂度。
+
+## 决定
+
+选择方案 C，并确定以下规则：
+
+1. Domain 增加冻结的 `PolicyFingerprint`、`ToolFingerprint` 和 `RunFingerprint`。hash 固定为 64 位小写
+   SHA-256，Tool 列表按名称排序且唯一。
+2. `ToolSpec` 增加显式 `spec_version`。hash 覆盖序列化后的完整 ToolSpec；schema 外的 prepare/validation
+   行为变化必须人工提升 `spec_version`。
+3. `FixedToolPolicy` 暴露可信 fingerprint。canonical contract 覆盖 evaluator version、排序 allowlist 和
+   固定 hard-denied side effects；它不包含单次请求、PolicyDecision、Grant 或 Approval。
+4. canonical JSON 使用 UTF-8、`sort_keys=True`、紧凑 separators 与 JSON domain 值；禁止 `repr()`、对象
+   identity、路径或注册顺序。
+5. Composition root 使用声明的 BearAgent package version、Registry snapshot 与 Policy fingerprint 构造
+   `RunFingerprint`，再作为必需 BearAgent 类型注入 AgentLoop。Application 不读取包元数据或具体 adapter。
+6. 新 Run 统一写 Event schema v4。`RunCreatedPayloadV4` 保存 fingerprint 和可选 Provider selection；其他
+   v4 payload 继续复用 v2 的 Provider-neutral shape。v1/v2/v3 永久可读。
+7. fingerprint 只存在于 `RunCreated` Event。`RunState`/SQLite projection 不增加字段；inspect 从 committed
+   Event 提取，legacy Run 返回 `null`，绝不按当前 Runtime 配置反推。
+8. `ErrorInfo.retryable` 是来源 hint；`ToolRetrySafety` 是粗粒度 contract hint。二者都不是
+   RecoveryDecision，也不能单独触发自动调用。
+9. K1-K6 crash tests 使用真实子进程、SQLite 和 production-compatible AgentLoop/Tool 路径。测试 wrapper 可
+   在精确边界写 marker 后 `os._exit`；生产代码不新增 durable phase、reconcile 或 fault hook contract。
+10. 文件 hash/marker 只作为测试 oracle。即使 K4 的目标已更新，只要 terminal Event 未提交，query/CLI 就
+    只能报告 Tool Activity `RUNNING`，不得补写 ToolCompleted、Artifact、RunSucceeded 或 `UNKNOWN`。
+
+`bearagent_version` 是声明的 build/package identity。本地 `0.1.0+local` 不足以唯一定位 Git commit，文档和
+CLI 不得把它称为完整代码 provenance；Tool/Policy hashes 只精确标识其声明 contract。
+
+## 带来的影响
+
+### 得到的好处
+
+- 历史 Run 可以说明使用了哪套声明的 Tool/Policy contract；
+- 注册顺序或进程变化不影响 identity，声明变化可见；
+- 新事实沿用 Event/version/compatibility 机制，不引入表级双写；
+- crash suite 为 P2 提供可信基线，同时不伪造恢复能力；
+- 移除 AgentLoop 对 v2/v3 新 Run 构造的运行期分支，版本选择更集中。
+
+### 接受的代价
+
+- 每个 Tool contract 行为变化需要维护 `spec_version`；漏升版本无法由 hash 自动发现；
+- Pydantic 生成 schema 的描述性变化也会改变 Tool hash，这是 declared contract identity 接受的保守变化；
+- inspect 读取完整有界 Event 历史后才能返回 fingerprint，当前 P1 查询上限继续适用；
+- 子进程 crash 测试比进程内异常注入更慢，并需要维护 Windows/Linux 一致入口；
+- v4 一旦写入，历史读取代码不能删除。
+
+## 迁移和回退
+
+SQLite schema v1 和 `0001_initial.sql` 不变。先部署 v4 parser/schema/query，再让 AgentLoop 创建 v4。旧
+Run 没有 fingerprint 时返回缺失，不迁移、不补写。
+
+回退时可以停止新 Run 创建或恢复旧入口，但必须保留 v4 payload/fingerprint 解析。不得修改历史 Event、
+projection、Artifact 或输出文件，也不得用当前配置生成伪历史 identity。
+
+## 怎样验证
+
+- canonical hash 的顺序稳定、字段敏感、跨进程和 schema snapshot 测试；
+- Event v1-v4 在内存与 SQLite contract suite 中得到相同 P1 projection；
+- production composition/new Run/inspect/CLI 测试证明 fingerprint 来自可信注册信息且不含 secret/路径；
+- Provider/Tool `retryable=true` 调用计数测试证明没有自动 retry；
+- K1-K6 子进程测试核对 Event 序列、projection、workspace hash、CLI 输出和调用 marker；
+- import boundary、Ruff、Pyright、全量 pytest、schema、governance、docs、site 和 package build。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,8 @@ ADR 只记录影响多个模块、以后难以反转的技术决定。标题直�
   — accepted
 - [ADR-0015：用户配置显式选择模型协议 adapter](ADR-0015-explicit-model-protocol-adapters.md)
   — accepted
+- [ADR-0016：Run 创建时保存可信契约身份，进程中断后只报告已提交事实](ADR-0016-run-contract-fingerprint-committed-crash-facts.md)
+  — accepted
 
 新决定使用 [ADR 模板](../templates/adr.md)。被新决定替代的 ADR 不删除，改为 `superseded` 并链接
 到替代它的文档。

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -50,7 +50,7 @@ flowchart TB
 | Tool 执行边界 | 有界 Tool 数据、精确 Registry、默认拒绝 Policy 和统一 ToolExecutor |
 | workspace 只读边界 | 一层目录列出、分段 UTF-8 读取、普通字符串搜索和跨平台路径拒绝 |
 | workspace 输出边界 | `outputs/**` UTF-8 原子创建/替换、Artifact 元数据和失败前旧目标保护 |
-| Agent 执行链 | 从已提交 Event 构造有界 Context，串行调用模型与 Tool，保存 v2 Activity 事实与 v4 Run contract identity |
+| Agent 执行链 | 从已提交 Event 构造有界 Context，串行调用模型与 Tool，以 schema v4 保存 v2-shaped Activity 事实和 Run contract identity |
 | 固定任务 | 五个版本化文件任务使用 Fake Provider 完成确定性验证；DeepSeek V4 suite v1.1.1 也通过同一 rubric 的真实 5/5 |
 | 用户入口 | `run/inspect/events` CLI、config v1、RunProfile v1/v2、human/JSON renderer 和安全退出码 |
 | 查询 | application query service 只通过 EventStore 读取 projection 与分页 Event，并重建 Artifact 元数据 |
@@ -185,6 +185,10 @@ P1 同时最多一个 active Activity。pause、cancel、Approval 和 `UNKNOWN` 
 Reducer 只接受同一 Run、连续 sequence、白名单类型和版本，以及合法的状态转换。它返回新的冻结
 `RunState`，不访问数据库、模型、工具、系统时钟或随机数。
 
+Tool terminal Event 如果携带 v2-shaped execution evidence，还必须与同版本 `ToolCallRequested` 中的
+原始 `ToolRequest` 完全一致。当前 schema v2、v3、v4 都执行这条跨 Event 校验；判断依据是解析后的
+payload shape，不是容易漏掉新版本的数字分支。
+
 ### 7.2 预算
 
 Run 创建时固定模型调用次数、工具调用次数、token、费用和总时间上限。模型/工具次数在请求 Event
@@ -284,8 +288,10 @@ contract；完整 ToolSpec 的 canonical JSON SHA-256 随 RunCreated v4 保存�
   -> ToolExecutor 限时执行并检查结果大小
 ```
 
-Registry 拒绝重名和模糊匹配。P1 Policy 默认拒绝，只允许程序启动时列出的名称，并且始终拒绝
-外部写入和代码执行。timeout、异常和超大结果会变成不同的安全 Error；Executor 不自动重试。
+Registry 为每个 Tool 只读取一次冻结 `ToolSpec`，再用同一份注册快照完成名称索引、Provider schema、
+Policy 检查和 Run fingerprint；它同时拒绝重名和模糊匹配。P1 Policy 默认拒绝，只允许程序启动时
+列出的名称，并且始终拒绝外部写入和代码执行。timeout、异常和超大结果会变成不同的安全 Error；
+Executor 不自动重试。
 `CancelledError` 原样传播。
 
 F-0007 的三个只读 Tool 和 F-0008 的 `workspace.write` 已通过这条路径运行测试。F-0016 增加了

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -50,7 +50,7 @@ flowchart TB
 | Tool 执行边界 | 有界 Tool 数据、精确 Registry、默认拒绝 Policy 和统一 ToolExecutor |
 | workspace 只读边界 | 一层目录列出、分段 UTF-8 读取、普通字符串搜索和跨平台路径拒绝 |
 | workspace 输出边界 | `outputs/**` UTF-8 原子创建/替换、Artifact 元数据和失败前旧目标保护 |
-| Agent 执行链 | 从已提交 Event 构造有界 Context，串行调用模型与 Tool，保存 v2 Activity 事实和 v3 Provider 选择 |
+| Agent 执行链 | 从已提交 Event 构造有界 Context，串行调用模型与 Tool，保存 v2 Activity 事实与 v4 Run contract identity |
 | 固定任务 | 五个版本化文件任务使用 Fake Provider 完成确定性验证；DeepSeek V4 suite v1.1.1 也通过同一 rubric 的真实 5/5 |
 | 用户入口 | `run/inspect/events` CLI、config v1、RunProfile v1/v2、human/JSON renderer 和安全退出码 |
 | 查询 | application query service 只通过 EventStore 读取 projection 与分页 Event，并重建 Artifact 元数据 |
@@ -61,7 +61,9 @@ flowchart TB
 workspace Tools、固定 Policy 和 AgentLoop 连接。F-0017 的离线测试覆盖三种 adapter、配置选择、
 Event v3 和五任务 live runner；它不会按厂商名、URL 或失败结果猜协议，也不会自动切换 endpoint。
 suite v1.1.1 已用 DeepSeek V4 经 production composition 完成四个普通任务与安全 canary，P1 以 5/5
-关闭并生成脱敏报告。这不代表其他服务或协议已付费联调；持久事实仍不等于进程重启后会自动继续。
+关闭并生成脱敏报告。F-0018 又让新 Run 保存 BearAgent、Policy 和 Tool 的声明 contract fingerprint，
+并用 K1-K6 hard-process suite 核对进程退出后的最后 committed fact。这不代表其他服务或协议已付费
+联调，也不表示进程重启后会自动继续。
 
 ### 3.2 Roadmap 中的后续方向（尚未形成当前实现）
 
@@ -135,6 +137,7 @@ adapter 把 Event 写成 JSON 或数据库字段。SDK 对象和数据库 row �
 - Message 包含 system、user、assistant、tool 角色，以及文本、工具请求和工具结果；
 - Error 包含稳定分类、代码、可重试标志和经过筛选的安全详情；
 - Event 包含自身 ID、Run ID、sequence、类型、版本、带时区时间和 JSON payload。
+- RunFingerprint 包含 BearAgent 声明版本、固定 Policy identity，以及按名称排序的 Tool contract identity。
 
 公开类型冻结、拒绝未知字段，并通过 JSON schema 快照审查变化。详细决定见
 [ADR-0007](../adr/ADR-0007-provider-neutral-domain-schemas.md)。
@@ -212,6 +215,11 @@ occurred_at, causation_id, correlation_id, payload
 
 不兼容 payload 使用新 schema version 和明确迁移/upcaster，不改变旧 JSON 的含义。
 
+F-0018 的新 Run 统一写 Event schema v4。`RunCreatedPayloadV4` 在已有目标、预算、AgentConfig 和可选
+Provider 选择之外保存 `RunFingerprint`。Fingerprint 由 composition root 根据 package version、
+`FixedToolPolicy` 和 Registry 中的 `ToolSpec` 构造；query 从 sequence 1 的 Event 读取，legacy Run 返回
+缺失，不用当前配置反推历史。SQLite 仍使用已有 `payload_json`，projection 和 migration 都不增加字段。
+
 ### 8.2 P2 将怎样恢复
 
 Runtime 启动后扫描非终态 Run。完整 Event 永远是事实来源；Checkpoint 只保存 sequence、版本和
@@ -263,8 +271,10 @@ P1 不自动 retry 或 fallback。调用方必须显式修正配置或重新启�
 ### 10.1 统一 Tool 路径
 
 F-0006 已建立统一入口。F-0007 在这条入口后实现 `workspace.list`、`workspace.read` 和
-`workspace.search`。每个 Tool 先用 `ToolSpec` 声明输入/输出 schema、副作用类别、timeout、输出上限
-和未来能否安全重试。`ToolResult` 返回结构化 JSON 或安全 Error，不只返回任意字符串。
+`workspace.search`。每个 Tool 先用 `ToolSpec` 声明 `spec_version`、输入/输出 schema、副作用类别、
+timeout、输出上限和粗粒度 retry safety。`spec_version` 标识 schema 之外的 prepare/validation 行为
+contract；完整 ToolSpec 的 canonical JSON SHA-256 随 RunCreated v4 保存。`ToolResult` 返回结构化 JSON
+或安全 Error，不只返回任意字符串。
 
 ```text
 模型提出 ToolRequest
@@ -389,11 +399,15 @@ bearagent doctor
 字段读取，并仅在创建 adapter 时解封。人类可读输出与 `--json`
 使用同一个 application result，不复制查询或状态规则。
 
-`inspect` 返回 Reducer projection、RunCreated v3 的安全 Provider 选择，以及从已提交 v2 Tool Event
-重建的 Artifact。`events` 使用有界页、
+`inspect` 返回 Reducer projection、RunCreated v4 的安全 Provider 选择与 RunFingerprint，以及从已提交
+v2 shape Tool Event 重建的 Artifact。旧 v1-v3 Run 没有 fingerprint 时明确返回缺失。`events` 使用有界页、
 sequence cursor 和 `has_more`；默认 human 输出不打印 payload，显式 `--json` 才导出完整 Event。查询
 只调用 EventStore port，数据库不存在时不会创建空库。进程中断后的非终态 Run 会原样显示，不会
 自动恢复或伪造 terminal 状态。
+
+K1-K6 测试会在 Tool requested/started、原子 replace 前后、projection transaction 和 Model started
+边界终止独立子进程，再用新 SQLite adapter 与 CLI 检查。即使 K4 的文件已经更新，只要 terminal Event
+没有提交，inspect 仍只显示 RUNNING，不构造 Artifact，也不根据 `retryable` 或 `ToolRetrySafety` 重试。
 
 ### 13.2 P4 HTTP/SSE
 
@@ -471,8 +485,8 @@ Policy/Approval、runner 隔离、日志脱敏和备份恢复演练。
 F-0008 已通过 ADR-0012 决定：P1 不设置 Artifact TTL，也不自动清理成功文件；崩溃残留和 reconcile
 留给 P2。对应后续 Feature 开始前仍需决定：
 
-- F-0012：SandboxBackend 选择、runner 资源上限和 Docker/Podman 边界；
-- F-0013/F-0014：P4 HTTP、自托管和备份恢复方案；
+- F-0024：SandboxBackend 选择、runner 资源上限和 Docker/Podman 边界；
+- F-0025/F-0026：P4 HTTP、自托管和备份恢复方案；
 - P4 Web UI：独立前端还是最小服务端页面；
 - 公开发布：Apache-2.0 或 AGPL-3.0。
 

--- a/docs/plans/PLAN-F-0018-p1-evidence-hardening.md
+++ b/docs/plans/PLAN-F-0018-p1-evidence-hardening.md
@@ -1,6 +1,6 @@
 ---
 title: "Implementation Plan: F-0018 P1 evidence hardening"
-status: active
+status: completed
 plan_id: PLAN-F-0018
 related_spec: F-0018
 created: 2026-08-28
@@ -62,7 +62,7 @@ last_updated: 2026-08-29
 
 ### 第 5 步：同步文档与所有质量门，关闭 Feature
 
-- 状态：in_progress；
+- 状态：completed；
 - 交付结果：Roadmap/Architecture/indexes/site/schema/status 与代码一致，Plan/Spec 准确收口；
 - 代码落点：Feature 文档列出的五个文档表面和 generated snapshots；
 - 接入关系：学习页解释用户可见 inspect；开发者页解释 identity/Event v4/crash boundary；
@@ -110,5 +110,5 @@ git diff --check
 - domain、CLI、runtime configuration 三组 schema 生成后 contract tests 通过；
 - Starlight production build：45 pages，Pagefind 索引完成；
 - sdist/wheel 构建成功，隔离安装 wheel 后的 `run/inspect/events` smoke 通过；
-- 当前只剩创建 immutable implementation commit、回填 Feature `implemented_in` 并完成治理关闭，因此
-  第 5 步和本 Plan 暂时保持 `in_progress` / `active`。
+- immutable implementation evidence：`commit 26f3203`；Feature `implemented_in`、Roadmap 与索引已同步，
+  第 5 步和本 Plan 完成。

--- a/docs/plans/PLAN-F-0018-p1-evidence-hardening.md
+++ b/docs/plans/PLAN-F-0018-p1-evidence-hardening.md
@@ -1,0 +1,114 @@
+---
+title: "Implementation Plan: F-0018 P1 evidence hardening"
+status: active
+plan_id: PLAN-F-0018
+related_spec: F-0018
+created: 2026-08-28
+last_updated: 2026-08-29
+---
+
+# PLAN-F-0018：强化 P1 执行契约身份与 crash observability
+
+关联 Spec：`docs/specs/F-0018-p1-evidence-hardening.md`
+
+## 开始前确认
+
+- [x] Spec status is `accepted`.
+- [x] 影响实现的开放问题已经解决。
+- [x] S2 的 ADR-0016 已接受，迁移/回退边界已经明确。
+
+## 实施步骤
+
+### 第 1 步：建立 contract fingerprint Value Objects 与 canonical hash
+
+- 状态：completed；
+- 交付结果：ToolSpec version、Policy/Tool/Run fingerprint、稳定 canonical JSON + SHA-256；
+- 代码落点：`domain/tools.py`、新的 domain/runtime fingerprint 模块、`runtime/policy.py`、四个 workspace Tool；
+- 接入关系：Registry 提供注册时 ToolSpec；FixedToolPolicy 提供静态 identity；纯 builder 只返回 domain 类型；
+- 重点测试：排序稳定、字段变化、版本规则、严格 schema、secret/路径拒绝；
+- 验证命令：fingerprint/tool/policy unit 与 contract/security tests；
+- 回退方式：在 Event v4 写入前可以删除新类型/字段；不得手工修改 schema snapshot。
+
+### 第 2 步：用 RunCreated v4 持久化并通过 inspect 展示
+
+- 状态：completed；
+- 交付结果：production composition 构造 fingerprint；AgentLoop 新 Run 统一写 v4；query/CLI 展示；
+- 代码落点：`bootstrap.py`、`application/agent_loop.py`、`domain/run_events.py`、`domain/queries.py`、
+  `application/run_queries.py`、CLI renderer/contracts/schema registry；
+- 接入关系：bootstrap 注入 domain fingerprint；EventStore 保存 v4 JSON；query 从 Event 读取，不读 adapter；
+- 重点测试：v1-v4 reducer/store/context/query compatibility、production composition、human/JSON inspect；
+- 验证命令：domain/schema/store/AgentLoop/query/CLI targeted tests；
+- 回退方式：保留 v4 parser/query 后停止新 Run 创建；不改旧 Event 或 SQLite migration。
+
+### 第 3 步：固定 failure hint 与 recovery permission 边界
+
+- 状态：completed；
+- 交付结果：ErrorInfo/ToolRetrySafety 注释和 schema 语义一致；retryable provider/tool 只执行一次；
+- 代码落点：domain errors/tools、recovery/security tests 与相关工程文档；
+- 接入关系：现有 Provider/Tool error 继续进入 AgentLoop；没有新 recovery policy；
+- 重点测试：provider retryable error、Tool retryable failure、NOT_SAFE workspace write contract；
+- 验证命令：AgentLoop/ToolExecutor/recovery/security targeted tests；
+- 回退方式：测试与注释可独立回退；不改旧 Event 字段名或值。
+
+### 第 4 步：建立 K1-K6 hard-process crash observability suite
+
+- 状态：completed；
+- 交付结果：无 sleep 的 child-process driver，K1-K6 在新 adapter/CLI 进程中复核 committed facts；
+- 代码落点：`tests/recovery/` 子进程 driver、fixtures 和 crash suite；production 代码不增加 recovery hook；
+- 接入关系：child 使用 SQLite、AgentLoop、workspace.write 和测试 wrapper；parent 通过 query/CLI 读取；
+- 重点测试：Event/projection/file/call marker/inspect/events、K4 无伪成功、K5 transaction rollback；
+- 验证命令：`uv run pytest tests/recovery/test_crash_observability.py -q`；
+- 回退方式：删除测试 harness 不影响 production；不得通过生产 reconcile 让测试通过。
+
+### 第 5 步：同步文档与所有质量门，关闭 Feature
+
+- 状态：in_progress；
+- 交付结果：Roadmap/Architecture/indexes/site/schema/status 与代码一致，Plan/Spec 准确收口；
+- 代码落点：Feature 文档列出的五个文档表面和 generated snapshots；
+- 接入关系：学习页解释用户可见 inspect；开发者页解释 identity/Event v4/crash boundary；
+- 重点测试：governance、docs links、site build、schema idempotence、package/wheel smoke、全量回归；
+- 验证命令：本 Plan 最终验证列表；
+- 回退方式：Feature 未通过全部门禁时保持 active/accepted，不声明实现完成。
+
+## 跨切片检查
+
+| 风险面 | 结果或 `N/A` + 原因 | 证据 |
+|---|---|---|
+| Persistence / recovery | v4 只扩展 payload JSON；旧 Event 可读；K1-K6 不恢复 | 474 tests + K1-K6 |
+| Permission / security | fingerprint 严格拒绝配置/Grant 字段，production Event 不含 Provider key | security + composition tests |
+| Timeout / cancel / limits | 既有上限不变；retryable Provider/Tool 各只调用一次 | recovery tests |
+| Migration / rollback | 无 SQL migration；v4 reader 必须保留 | ADR-0016 |
+| Logs / trace / metrics | 不新增 trace；inspect/events 只展示 committed Event | K1-K6 CLI assertions |
+| Documentation impact | docs、学习页、开发者页、当前状态和 schema 已同步 | docs/site checks |
+
+## 最终验证
+
+计划运行：
+
+```powershell
+$env:UV_CACHE_DIR='D:\BearAgent\.uv-cache'
+uv lock --check
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest --basetemp=.pytest-tmp-f0018 -o cache_dir=.pytest-state-f0018
+uv run python scripts/generate_domain_schemas.py
+uv run python scripts/generate_cli_schemas.py
+uv run python scripts/generate_runtime_configuration_schemas.py
+uv run python scripts/check_governance.py
+uv run python scripts/check_docs.py
+npm.cmd run build --prefix=site
+uv build
+git diff --check
+```
+
+2026-08-29 实际结果：
+
+- `uv lock --check`、Ruff、format、Pyright、governance、140 个 Markdown 本地链接和 `git diff --check`
+  通过；
+- 全量 pytest：474 passed；其中 K1-K6 使用 5 个 hard-exit 子进程和 1 个 SQLite transaction 故障注入；
+- domain、CLI、runtime configuration 三组 schema 生成后 contract tests 通过；
+- Starlight production build：45 pages，Pagefind 索引完成；
+- sdist/wheel 构建成功，隔离安装 wheel 后的 `run/inspect/events` smoke 通过；
+- 当前只剩创建 immutable implementation commit、回填 Feature `implemented_in` 并完成治理关闭，因此
+  第 5 步和本 Plan 暂时保持 `in_progress` / `active`。

--- a/docs/plans/PLAN-F-0018-p1-evidence-hardening.md
+++ b/docs/plans/PLAN-F-0018-p1-evidence-hardening.md
@@ -4,7 +4,7 @@ status: completed
 plan_id: PLAN-F-0018
 related_spec: F-0018
 created: 2026-08-28
-last_updated: 2026-08-29
+last_updated: 2026-09-02
 ---
 
 # PLAN-F-0018：强化 P1 执行契约身份与 crash observability
@@ -74,7 +74,7 @@ last_updated: 2026-08-29
 
 | 风险面 | 结果或 `N/A` + 原因 | 证据 |
 |---|---|---|
-| Persistence / recovery | v4 只扩展 payload JSON；旧 Event 可读；K1-K6 不恢复 | 474 tests + K1-K6 |
+| Persistence / recovery | v4 只扩展 payload JSON；旧 Event 可读；K1-K6 不恢复 | 474 tests at closure；481 tests after audit |
 | Permission / security | fingerprint 严格拒绝配置/Grant 字段，production Event 不含 Provider key | security + composition tests |
 | Timeout / cancel / limits | 既有上限不变；retryable Provider/Tool 各只调用一次 | recovery tests |
 | Migration / rollback | 无 SQL migration；v4 reader 必须保留 | ADR-0016 |
@@ -112,3 +112,17 @@ git diff --check
 - sdist/wheel 构建成功，隔离安装 wheel 后的 `run/inspect/events` smoke 通过；
 - immutable implementation evidence：`commit 26f3203`；Feature `implemented_in`、Roadmap 与索引已同步，
   第 5 步和本 Plan 完成。
+
+## 2026-09-02 完成后全仓审计
+
+- 修复 `validate_event_history` 只列举 schema v2/v3、导致 v4 Tool terminal evidence 绕过原始请求
+  一致性检查的问题；现在按解析后的 v2-shaped payload 类型分派，v2/v3/v4 都运行同一规则；
+- `ToolRegistry` 构造时只读取每个 Tool 的一次冻结 `ToolSpec`，避免名称索引与真正用于 Policy、Provider
+  schema 和 fingerprint 的注册快照分叉；
+- 合并 CLI 三个命令中语义重复的异常分支；删除未调用的 OpenAI 私有 helper 和未实现的空
+  `adapters/sandbox` 占位包，没有新增 P2/P3 类型或行为；
+- 同步 Spec、ADR、Architecture、Roadmap，以及 Reducer、EventStore、Tool、AgentLoop、milestone 和状态
+  开发者文档；学习页与 README 为 `N/A`，因为合法 CLI 行为和读者操作路径没有变化；
+- 最终结果：481 tests passed；Ruff、format、Pyright、三个 schema 生成器、governance、140 个 Markdown
+  链接、45 页 Starlight build、sdist/wheel 和隔离安装后的 `doctor`、`run/inspect/events` smoke 全部通过；
+  domain/CLI/runtime configuration schema 与 SQLite migration 均无变化。

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -20,10 +20,11 @@ Plan 不重复 Spec 的需求，也不代替 ADR。开始前确认 Spec 已 `acc
 
 ## 当前计划
 
-- [PLAN-F-0018：强化 P1 执行契约身份与 crash observability](PLAN-F-0018-p1-evidence-hardening.md) — active
+当前没有 active Plan。
 
 ## 已完成计划
 
+- [PLAN-F-0018：强化 P1 执行契约身份与 crash observability](PLAN-F-0018-p1-evidence-hardening.md)
 - [PLAN-F-0015：建立并重写 Starlight 文档站](PLAN-F-0015-local-starlight-docs-site.md)
 - [PLAN-F-0001：内部 ID、Message、Error 和 Event](PLAN-F-0001-domain-ids-messages-errors.md)
 - [PLAN-F-0002：Run/Activity 状态和预算](PLAN-F-0002-run-reducer-activity-lifecycle-budgets.md)

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -20,7 +20,7 @@ Plan 不重复 Spec 的需求，也不代替 ADR。开始前确认 Spec 已 `acc
 
 ## 当前计划
 
-- 无。
+- [PLAN-F-0018：强化 P1 执行契约身份与 crash observability](PLAN-F-0018-p1-evidence-hardening.md) — active
 
 ## 已完成计划
 

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -67,7 +67,7 @@ P0 建立 Python 3.12、uv、CI、CLI、模块依赖检查、测试替身，以�
 
 ### P1：可检查执行
 
-**P1 基线状态：已完成。** F-0001 至 F-0008、F-0015、F-0016 和 F-0017 均已实现。Runtime gate 在
+**P1 状态：已完成。** F-0001 至 F-0008、F-0015 至 F-0018 均已实现。Runtime gate 在
 2026-08-23 完成；F-0015 随后完成书籍化文档重构和本地站点验收。F-0018 是进入 P2 前的增量 evidence
 hardening；它不重写 P1 exit criteria，也不把已关闭的 P1 基线改回进行中。
 
@@ -83,7 +83,7 @@ P1 已接通：
 v1.1.1 使用 DeepSeek V4 经 production composition 完成四个普通任务和一个安全 canary，结果为
 5/5。证据见 [F-0017 P1 live report](../evidence/F-0017-p1-live-report-v1.json)。
 
-P1 只保证已保存事实可查。F-0018 完成后，新 Run 还会记录可信 Tool/Policy contract identity，并用
+P1 只保证已保存事实可查。F-0018 让新 Run 记录可信 Tool/Policy contract identity，并用
 hard-process 测试验证最后 committed fact 的可见性。进程退出后仍不会自动继续；timeout 也不会撤销
 可能已经发生的副作用。
 
@@ -327,7 +327,7 @@ Spec 的 P2/P3/P4 占位 ID 统一顺延；这次重排不改变任何已接受�
 9. [F-0015：可以连续阅读的 Starlight 文档书](../specs/F-0015-local-starlight-docs-site.md) — implemented
 10. [F-0016：有界 Context 和串行 Agent Loop](../specs/F-0016-bounded-context-agent-loop.md)
 11. [F-0017：模型服务配置与真实 gate](../specs/F-0017-configurable-model-providers-live-gate.md)
-12. [F-0018：可信 Run contract identity 与 crash observability](../specs/F-0018-p1-evidence-hardening.md) — accepted
+12. [F-0018：可信 Run contract identity 与 crash observability](../specs/F-0018-p1-evidence-hardening.md) — implemented
 
 F-0015 的文档内容、本地站点、构建和阅读体验已经实现；部署到某个在线平台不在该 Feature 范围内。
 

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -67,8 +67,9 @@ P0 建立 Python 3.12、uv、CI、CLI、模块依赖检查、测试替身，以�
 
 ### P1：可检查执行
 
-**状态：已完成。** F-0001 至 F-0008、F-0015、F-0016 和 F-0017 均已实现。Runtime gate 在
-2026-08-23 完成；F-0015 随后完成书籍化文档重构和本地站点验收。
+**P1 基线状态：已完成。** F-0001 至 F-0008、F-0015、F-0016 和 F-0017 均已实现。Runtime gate 在
+2026-08-23 完成；F-0015 随后完成书籍化文档重构和本地站点验收。F-0018 是进入 P2 前的增量 evidence
+hardening；它不重写 P1 exit criteria，也不把已关闭的 P1 基线改回进行中。
 
 P1 已接通：
 
@@ -82,7 +83,9 @@ P1 已接通：
 v1.1.1 使用 DeepSeek V4 经 production composition 完成四个普通任务和一个安全 canary，结果为
 5/5。证据见 [F-0017 P1 live report](../evidence/F-0017-p1-live-report-v1.json)。
 
-P1 只保证已保存事实可查。进程退出后不会自动继续；timeout 也不会撤销可能已经发生的副作用。
+P1 只保证已保存事实可查。F-0018 完成后，新 Run 还会记录可信 Tool/Policy contract identity，并用
+hard-process 测试验证最后 committed fact 的可见性。进程退出后仍不会自动继续；timeout 也不会撤销
+可能已经发生的副作用。
 
 F-0015 提供独立的 Starlight 文档站、渐进式学习路线、CLI 手册和源码导读。它可以本地开发、构建
 和预览，普通 CI 负责验证；在线托管与自动部署不属于 F-0015，也不再作为 P1 的关闭门。
@@ -307,10 +310,11 @@ P5 把 P1 任务、P2 恢复演练和 P3 安全演练接入统一追踪，比较
 
 ## 11. Feature Backlog
 
-Feature ID 在全项目稳定。未创建 Spec 的名称只表示计划范围；开始前必须创建 Spec 并声明 milestone。
-移动阶段时不重编号。下面对 F-0013/F-0014 的调整只改变尚未创建 Spec 的计划归属。
+Feature ID 在 Spec 创建后保持稳定。未创建 Spec 的名称只表示计划范围；开始前必须创建 Spec 并声明
+milestone。2026-08-28 为让完成的 P1 Feature 和后续阶段按顺序阅读，项目所有者明确要求把尚未创建
+Spec 的 P2/P3/P4 占位 ID 统一顺延；这次重排不改变任何已接受或已实现 Feature 的 ID。
 
-### P1（已完成）
+### P1（基线已完成；pre-P2 hardening 进行中）
 
 1. [F-0001：内部 ID、Message 和 Error](../specs/F-0001-domain-ids-messages-errors.md)
 2. [F-0002：Run/Activity 状态和预算](../specs/F-0002-run-reducer-activity-lifecycle-budgets.md)
@@ -323,29 +327,30 @@ Feature ID 在全项目稳定。未创建 Spec 的名称只表示计划范围；
 9. [F-0015：可以连续阅读的 Starlight 文档书](../specs/F-0015-local-starlight-docs-site.md) — implemented
 10. [F-0016：有界 Context 和串行 Agent Loop](../specs/F-0016-bounded-context-agent-loop.md)
 11. [F-0017：模型服务配置与真实 gate](../specs/F-0017-configurable-model-providers-live-gate.md)
+12. [F-0018：可信 Run contract identity 与 crash observability](../specs/F-0018-p1-evidence-hardening.md) — accepted
 
 F-0015 的文档内容、本地站点、构建和阅读体验已经实现；部署到某个在线平台不在该 Feature 范围内。
 
 ### P2（计划；均未创建 Spec）
 
-1. F-0009：Event-only 状态重建、Checkpoint fallback 和启动检查
-2. F-0010：Attempt、失败分类、恢复语义和有界 retry
-3. F-0018：幂等键、Receipt、reconcile 和 `UNKNOWN` 处置
-4. F-0019：pause/resume/cancel/retry 命令与完整 kill-point suite
+1. F-0019：Event-only 状态重建、Checkpoint fallback 和启动检查
+2. F-0020：Attempt、失败分类、恢复语义和有界 retry
+3. F-0021：幂等键、Receipt、reconcile 和 `UNKNOWN` 处置
+4. F-0022：pause/resume/cancel/retry 命令与完整 kill-point suite
 
 ### P3（计划；均未创建 Spec）
 
-1. F-0011：Grant、三态 Policy 和持久化参数绑定 Approval
-2. F-0012：SandboxBackend、隔离 runner 和受控 shell/code Tool
+1. F-0023：Grant、三态 Policy 和持久化参数绑定 Approval
+2. F-0024：SandboxBackend、隔离 runner 和受控 shell/code Tool
 
 ### P4（计划；均未创建 Spec）
 
-1. F-0013：HTTP API、SSE 续接和单用户认证
-2. F-0014：Compose 加固、HTTPS、备份和空目录恢复
-3. F-0020：版本化只读 Skill
-4. F-0021：受控 MCP Tool
-5. F-0022：Web UI
-6. F-0023：有来源、可删除的 Memory 和上下文压缩
+1. F-0025：HTTP API、SSE 续接和单用户认证
+2. F-0026：Compose 加固、HTTPS、备份和空目录恢复
+3. F-0027：版本化只读 Skill
+4. F-0028：受控 MCP Tool
+5. F-0029：Web UI
+6. F-0030：有来源、可删除的 Memory 和上下文压缩
 
 如果一个条目在写 Spec 时仍无法独立验收，保留现有 ID 的核心范围，并用新的全局 ID 拆出后续
 Feature。一个 Plan 不得同时实现整个阶段。

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -79,9 +79,11 @@ P1 已接通：
 - 默认拒绝 Policy、workspace 读写 Tool、原子 Artifact 和串行 Agent Loop；
 - `run/inspect/events` CLI、Fake 任务集、真实模型 gate 和脱敏证据。
 
-最终离线门禁通过 445 个测试、schema、链接、35 页站点、sdist/wheel 和隔离 CLI smoke。suite
-v1.1.1 使用 DeepSeek V4 经 production composition 完成四个普通任务和一个安全 canary，结果为
-5/5。证据见 [F-0017 P1 live report](../evidence/F-0017-p1-live-report-v1.json)。
+F-0017 关闭时的离线门禁通过 445 个测试、schema、链接、35 页站点、sdist/wheel 和隔离 CLI smoke。
+suite v1.1.1 使用 DeepSeek V4 经 production composition 完成四个普通任务和一个安全 canary，结果为
+5/5。证据见 [F-0017 P1 live report](../evidence/F-0017-p1-live-report-v1.json)。F-0018 关闭时进一步通过
+474 个测试、K1-K6 与 45 页站点构建；后续 2026-09-02 全仓审计又补齐 schema v4 Tool evidence 的
+跨 Event 一致性回归。
 
 P1 只保证已保存事实可查。F-0018 让新 Run 记录可信 Tool/Policy contract identity，并用
 hard-process 测试验证最后 committed fact 的可见性。进程退出后仍不会自动继续；timeout 也不会撤销

--- a/docs/specs/F-0018-p1-evidence-hardening.md
+++ b/docs/specs/F-0018-p1-evidence-hardening.md
@@ -6,7 +6,7 @@ milestone: P1
 change_level: S2
 owner: CherryYang05
 created: 2026-08-28
-last_updated: 2026-08-29
+last_updated: 2026-09-02
 implemented_in: "commit 26f3203"
 related_adrs: [ADR-0002, ADR-0003, ADR-0004, ADR-0007, ADR-0012, ADR-0013, ADR-0014, ADR-0016]
 ---
@@ -114,6 +114,9 @@ package version -------┘                                  |
 
 - 新 Run 的全部 P1 Event 使用 schema v4；`RunCreatedPayloadV4` 在 v2 的 objective/AgentConfig 上增加
   `run_fingerprint`，并保留可选的非敏感 `provider_selection`；
+- 使用 v2 execution evidence shape 的 Tool terminal Event（当前为 schema v2/v3/v4）必须与同版本
+  `ToolCallRequested` 中的原始 `ToolRequest` 值相等；Reducer 按解析后的 payload shape 执行这条跨 Event
+  校验，不能靠列举旧版本号决定是否校验；
 - Event v1/v2/v3 payload 含义不变并继续由相同 registry 解析；
 - Reducer 从任意受支持 `RunCreatedPayload` 取得 Session/预算，`RunState` 与 SQLite projection schema 不增加
   fingerprint 字段；
@@ -157,6 +160,7 @@ Run，但不能删除 v4 payload/fingerprint 读取代码。回退不得修改�
 | AC-8 | Event/projection transaction 故障后重开无部分提交 | crash observability K5 + SQLite tests |
 | AC-9 | core/application import 边界、schema、治理、docs、site、package build 和全量测试通过 | 最终验证命令 |
 | AC-10 | 代码与文档没有新增任何 P2/P3 domain 类型或行为 | diff review + governance/docs checks |
+| AC-11 | v2/v3/v4 Tool terminal evidence 都不能把 requested Event 中的原始 ToolRequest 替换成另一请求 | Reducer unit + memory/SQLite Store contract tests |
 
 ## 9. 文档影响
 
@@ -172,3 +176,11 @@ Run，但不能删除 v4 payload/fingerprint 读取代码。回退不得修改�
 
 - OQ-1：N/A。字段、兼容、hash 与 crash harness 边界已由 ADR-0016 决定；实现发现新恢复需求时记录为
   P2 Feature，不扩大本 Spec。
+
+## 11. 完成后维护记录
+
+2026-09-02 的 P1 全仓审计发现：`validate_event_history` 曾用 `{2, 3}` 决定是否核对 Tool terminal
+evidence，导致 F-0018 新增的 schema v4 绕过同一条原始请求一致性检查。修复改为先解析 payload，再按
+`ToolCallCompletedPayloadV2` / `ToolCallFailedPayloadV2` shape 决定是否检查；v2/v3/v4 共用同一组
+Reducer 与两个 Store contract 用例。该修复只拒绝不可信的矛盾历史，不增加 retry、reconcile、恢复或
+授权语义。

--- a/docs/specs/F-0018-p1-evidence-hardening.md
+++ b/docs/specs/F-0018-p1-evidence-hardening.md
@@ -1,13 +1,13 @@
 ---
 title: "Feature: identify trusted Run contracts and expose committed crash boundaries"
-status: accepted
+status: implemented
 spec_id: F-0018
 milestone: P1
 change_level: S2
 owner: CherryYang05
 created: 2026-08-28
-last_updated: 2026-08-28
-implemented_in: null
+last_updated: 2026-08-29
+implemented_in: "commit 26f3203"
 related_adrs: [ADR-0002, ADR-0003, ADR-0004, ADR-0007, ADR-0012, ADR-0013, ADR-0014, ADR-0016]
 ---
 

--- a/docs/specs/F-0018-p1-evidence-hardening.md
+++ b/docs/specs/F-0018-p1-evidence-hardening.md
@@ -1,0 +1,174 @@
+---
+title: "Feature: identify trusted Run contracts and expose committed crash boundaries"
+status: accepted
+spec_id: F-0018
+milestone: P1
+change_level: S2
+owner: CherryYang05
+created: 2026-08-28
+last_updated: 2026-08-28
+implemented_in: null
+related_adrs: [ADR-0002, ADR-0003, ADR-0004, ADR-0007, ADR-0012, ADR-0013, ADR-0014, ADR-0016]
+---
+
+# F-0018：记录 Run 使用的可信执行契约，并展示进程中断前最后确认的事实
+
+## 1. 问题与证据
+
+P1 已保存模型请求、Tool 请求、PolicyDecision、ToolResult、Artifact 和预算事实，但一个历史 Run 只记录
+Tool 名称和当次 Policy 结果。以后 Tool schema、`prepare` 规范化、资源限制或固定 Policy 配置变化时，
+调用方无法从 `RunCreated` 判断当时使用的是哪一版可信 Tool/Policy contract。
+
+现有 `tests/recovery/test_agent_loop_boundaries.py` 已证明 Event append 失败后不会重复模型或 Tool 调用，
+也覆盖“`workspace.write` 已替换目标但 terminal Event 未保存”。这些测试仍运行在同一 Python 进程，
+没有验证 SQLite/WAL、projection、workspace 和 CLI 在 hard process death 后共同呈现什么事实。
+
+`ErrorInfo.retryable` 和 `ToolRetrySafety` 已用于描述错误来源及 Tool contract，但它们必须在进入 P2 前
+明确保持为观察/声明信息，不能被未来代码直接当成恢复授权。
+
+## 2. 目标与非目标
+
+### 本次交付
+
+- G-1：每个新 Run 在创建时保存可信、有限、非敏感且不可变的 `RunFingerprint`；
+- G-2：为注册时 `ToolSpec` 增加显式 `spec_version`，并为 Tool/Policy contract 生成确定性 SHA-256；
+- G-3：使用新的 `RunCreated` Event schema 保存 fingerprint，旧 Event 和 SQLite 数据继续可读；
+- G-4：`inspect` 展示 fingerprint，Event 仍是事实来源，projection 不成为第二份真相；
+- G-5：用测试和代码契约明确 `retryable`、`ToolRetrySafety` 不构成 RecoveryDecision；
+- G-6：在真实子进程终止边界验证 K1-K6，只展示最后 committed fact，不补写结论。
+
+### 本次不做
+
+- NG-1：不增加 Attempt、Receipt、ExecutionPhase、RecoveryEvidence、RecoveryDecision 或 `UNKNOWN`；
+- NG-2：不增加 retry、reconcile、resume、startup scan、Checkpoint 或 postcondition recovery；
+- NG-3：不增加 Grant、Approval、三态 Policy、SandboxBackend、shell/code Tool 或新的权限入口；
+- NG-4：不新增 `trace` CLI，不重构 causation/correlation public contract；
+- NG-5：fingerprint 不保存完整实现、Git working tree、SDK/client、路径、secret、Prompt 或 Tool 输出；
+- NG-6：不把本 Feature 扩成通用 AgentLoop、Reducer、Provider adapter 或 tracing 重构。
+
+## 3. 场景与可观察行为
+
+### 3.1 新 Run 保存执行契约身份
+
+- FR-1：`RunFingerprint` 最终形状为 `bearagent_version`、一个 Policy fingerprint 和按 Tool 名称排序的
+  Tool fingerprints；
+- FR-2：Policy fingerprint 包含稳定 `version` 与 64 位小写十六进制 `sha256`；
+- FR-3：每个 Tool fingerprint 包含 `name`、`spec_version` 与 `sha256`；Tool 名称必须唯一并稳定排序；
+- FR-4：Tool hash 覆盖完整、序列化后的注册时 `ToolSpec`，包括 description、schema、副作用、timeout、
+  输入/输出上限、retry safety 和 `spec_version`；
+- FR-5：Policy hash 覆盖固定 evaluator version、排序后的 allowlist 与固定硬拒绝副作用集合；
+- FR-6：相同语义输入使用 UTF-8、排序 key、紧凑 separators 的 canonical JSON，跨注册顺序得到同一 hash；
+- FR-7：`spec_version` 负责标识 schema JSON 之外的行为 contract，例如 `prepare` 规范化或边界校验；
+  这是一条人工版本纪律，hash 不声称自动覆盖 adapter 全部实现。
+
+### 3.2 fingerprint 只提供有限 provenance
+
+- FR-8：`bearagent_version` 使用已安装 BearAgent 包声明的版本；本地源码回退版本不声称能唯一定位 Git
+  commit；
+- FR-9：fingerprint 表示声明的 BearAgent build identity 与 Tool/Policy contract identity，不是完整历史
+  代码快照、恢复证据、Grant、capability 或单次 PolicyDecision；
+- FR-10：模型、Prompt、Skill、workspace、ToolResult 和 Provider 响应都不能提供或覆盖 fingerprint 字段。
+
+### 3.3 failure hint 不触发恢复
+
+- FR-11：`ErrorInfo.retryable` 只表示错误来源给出的 transient/retryable hint；
+- FR-12：`ToolRetrySafety` 只描述可信 Tool contract 的粗粒度重试属性；
+- FR-13：任一字段都不能授权 P1 发起第二次模型或 Tool 调用；Provider/Tool 返回 `retryable=true` 时，
+  当前 Activity 仍按既有 P1 路径结束或交回模型，不产生隐藏 retry。
+
+### 3.4 crash 后只展示已提交事实
+
+- FR-14：K1 在 `ToolCallRequested` 提交后终止，重开后 Activity 为 `PENDING`，Tool 未执行；
+- FR-15：K2 在 `ToolCallStarted` 提交后、adapter 进入前终止，重开后 Activity 为 `RUNNING`；
+- FR-16：K3 在临时文件 fsync 后、`os.replace` 前终止，目标保持旧内容或不存在，且没有 Tool terminal Event；
+- FR-17：K4 在 `os.replace` 后、ToolResult/Event 保存前终止，目标可能已更新，但 inspect 不宣称成功，
+  不构造 Artifact，也不重试；
+- FR-18：K5 在 Event insert/projection update transaction 提交前故障，重开后两者都不存在部分提交；
+- FR-19：K6 在 `ModelCallStarted` 后终止，重开后不补 `ModelCallFailed`、usage 或第二次 Provider 调用；
+- FR-20：测试可直接读取文件或调用 marker 作为 oracle，但 production Runtime 不把 oracle 转换成新 Event。
+
+## 4. 对外入口与模块连接
+
+`bearagent run` 参数不变。Production composition 从包版本、注册时 `ToolSpec` 和固定 Policy 的可信静态
+配置构造 `RunFingerprint`，再注入 `AgentLoop`。Application 只接收 BearAgent domain 类型，不读取包元数据、
+adapter 或本机路径。
+
+```text
+ToolRegistry specs ----┐
+FixedToolPolicy -------+--> pure fingerprint builder --> RunFingerprint
+package version -------┘                                  |
+                                                           v
+                                            AgentLoop -> RunCreated v4
+                                                           |
+                                                           v
+                                            EventStore -> RunQueryService
+                                                           |
+                                                           v
+                                                        inspect
+```
+
+`run events --json` 继续返回原始 Event envelope/payload；`inspect` 的 domain/CLI JSON 增加可选 fingerprint，
+旧 Run 返回 `null`。Human inspect 显示完整版本和 hashes，不打印输入配置或路径。
+
+## 5. 状态与持久化
+
+- 新 Run 的全部 P1 Event 使用 schema v4；`RunCreatedPayloadV4` 在 v2 的 objective/AgentConfig 上增加
+  `run_fingerprint`，并保留可选的非敏感 `provider_selection`；
+- Event v1/v2/v3 payload 含义不变并继续由相同 registry 解析；
+- Reducer 从任意受支持 `RunCreatedPayload` 取得 Session/预算，`RunState` 与 SQLite projection schema 不增加
+  fingerprint 字段；
+- SQLite 继续把 v4 payload 写入现有 `payload_json`，不修改 `0001_initial.sql`，不增加 migration；
+- query service 从 sequence 1 的 committed `RunCreated` 提取 fingerprint/provider selection；缺失表示 legacy
+  Run，不从当前 Registry/Policy 反推历史值。
+
+## 6. 失败、恢复与安全边界
+
+- canonicalization 只接受 domain 已验证的 JSON；禁止 `repr()`、对象地址、注册顺序和本机环境进入 hash；
+- fingerprint 类型只允许有界版本字符串、Tool 名称和 SHA-256，不提供能承载任意配置的详情字段；
+- security tests 使用 marker 扫描 Event 与 inspect JSON，确认 API key、authorization、cookie、credential、
+  password、secret、token、Provider repr、workspace/database 绝对路径均未进入；
+- fingerprint 合法与否不改变 Policy 结果；执行仍只经过 Registry -> prepare -> Policy -> Executor；
+- crash suite 使用子进程 `os._exit` 和确定性 marker，不使用 `sleep` 猜测时序；结束后用新的 SQLite adapter
+  与 CLI 进程读取；
+- K3/K4 的测试 seam 位于测试 adapter/wrapper，不把 test hook、ExecutionPhase 或 recovery state 加入生产
+  domain；
+- hard exit 后不自动清理临时文件，不扫描非终态 Run，也不追加任何 Event。
+
+## 7. 上线与回退
+
+没有 feature flag 或 SQL migration。新代码先增加 v4 读取，再让 AgentLoop 写 v4。上线后可以停止创建新
+Run，但不能删除 v4 payload/fingerprint 读取代码。回退不得修改历史 Event、数据库、Artifact 或
+`outputs/**`。
+
+若 fingerprint 实现需要回退，可保留 v4 parser/query 兼容并停止新 Run 入口；不能把旧 Run 用当前配置
+重新计算成看似真实的历史 fingerprint。
+
+## 8. 验收标准与证据
+
+| AC | 可判断的结果 | 证据路径或命令 |
+|---|---|---|
+| AC-1 | 相同 Tool/Policy contract 跨顺序产生相同 hash，任一声明字段变化会改变对应 hash | `tests/unit/test_run_fingerprints.py` |
+| AC-2 | 新 Run 写 v4 fingerprint；旧 v1/v2/v3 Event 与 SQLite 继续读取 | domain/store/query contract tests |
+| AC-3 | inspect human/JSON 展示新 fingerprint，legacy Run 显示缺失而非伪造 | CLI/query tests |
+| AC-4 | fingerprint 不包含 secret、路径、Provider client，也不能扩大 Policy | security tests |
+| AC-5 | `retryable=true` 和 `ToolRetrySafety` 都不产生自动第二次调用 | AgentLoop/ToolExecutor recovery tests |
+| AC-6 | K1-K6 在 Windows/Linux 可重复运行并断言 Event、projection、文件、CLI 与调用 marker | `tests/recovery/test_crash_observability.py` |
+| AC-7 | K4 文件已变化但没有 Tool terminal/Artifact/伪成功，也没有 retry/reconcile | crash observability K4 |
+| AC-8 | Event/projection transaction 故障后重开无部分提交 | crash observability K5 + SQLite tests |
+| AC-9 | core/application import 边界、schema、治理、docs、site、package build 和全量测试通过 | 最终验证命令 |
+| AC-10 | 代码与文档没有新增任何 P2/P3 domain 类型或行为 | diff review + governance/docs checks |
+
+## 9. 文档影响
+
+| 表面 | 更新路径，或 `N/A` + 原因 |
+|---|---|
+| Engineering `docs/` | 本 Spec、ADR-0016、Plan、Roadmap、Architecture、Spec/ADR/Plan indexes |
+| Site beginner path | 更新 `learn/run-inspect-events.md`，解释 fingerprint 与 crash 后最后 committed fact |
+| Site developer docs | 更新 AgentLoop/EventStore/Tool contract 相关页面，说明 v4 与 canonical identity |
+| Site current status | 更新 `project/status.md`，只声明 evidence hardening，不声明 crash recovery |
+| Generated reference | 更新 domain/CLI Schema snapshots；SQLite migration N/A，因为只复用 Event JSON |
+
+## 10. 尚未决定的问题
+
+- OQ-1：N/A。字段、兼容、hash 与 crash harness 边界已由 ADR-0016 决定；实现发现新恢复需求时记录为
+  P2 Feature，不扩大本 Spec。

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -36,7 +36,7 @@ S1 使用精简范围：问题、目标/非目标、可观察行为、必要失�
 - [F-0015：建立可以连续阅读的中文文档站](F-0015-local-starlight-docs-site.md) — implemented
   （本地开发、构建、预览、书籍化路线和 CLI 手册已完成；在线托管不在 Feature 范围内）
 - [F-0017：配置自己的模型服务，并用真实模型完成可检查文件任务](F-0017-configurable-model-providers-live-gate.md) — implemented
-- [F-0018：记录 Run 使用的可信执行契约，并展示进程中断前最后确认的事实](F-0018-p1-evidence-hardening.md) — accepted
+- [F-0018：记录 Run 使用的可信执行契约，并展示进程中断前最后确认的事实](F-0018-p1-evidence-hardening.md) — implemented
 
 其余计划 Feature 见[路线图 Backlog](../project/roadmap.md#11-feature-backlog)。未创建 Spec 的名称只是
 计划范围，不能授权实现。

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -36,6 +36,7 @@ S1 使用精简范围：问题、目标/非目标、可观察行为、必要失�
 - [F-0015：建立可以连续阅读的中文文档站](F-0015-local-starlight-docs-site.md) — implemented
   （本地开发、构建、预览、书籍化路线和 CLI 手册已完成；在线托管不在 Feature 范围内）
 - [F-0017：配置自己的模型服务，并用真实模型完成可检查文件任务](F-0017-configurable-model-providers-live-gate.md) — implemented
+- [F-0018：记录 Run 使用的可信执行契约，并展示进程中断前最后确认的事实](F-0018-p1-evidence-hardening.md) — accepted
 
 其余计划 Feature 见[路线图 Backlog](../project/roadmap.md#11-feature-backlog)。未创建 Spec 的名称只是
 计划范围，不能授权实现。

--- a/site/src/content/docs/zh-cn/architecture/p1-decisions.md
+++ b/site/src/content/docs/zh-cn/architecture/p1-decisions.md
@@ -14,6 +14,8 @@ sourceRefs:
   - ADR-0012
   - ADR-0013
   - ADR-0014
+  - ADR-0016
+  - F-0018
 ---
 
 P1 的目标不是“接一个模型，再给它几个函数”。它要让一次本地文件任务完成后，用户能回答：
@@ -81,6 +83,11 @@ projection，不是第二份事实来源。
 **重要边界：** Event 已持久化不等于 Runtime 会自动恢复。P1 可以重开数据库查询事实，但启动扫描、
 Checkpoint、Attempt 和恢复决定属于 P2。
 
+**Run 使用了哪套声明：** F-0018 让 bootstrap 根据 package version、固定 Policy 和 Registry 中的完整
+ToolSpec 构造 `RunFingerprint`，随 RunCreated v4 一次保存。Tool hash 会覆盖 schema、资源上限、副作用
+和 retry safety；`spec_version` 负责标识 schema 外的 prepare/validation contract。Fingerprint 不进入
+projection，也不是代码快照、权限或恢复证据。旧 Run 缺失时保持缺失，不能拿当前配置补历史。
+
 ## 4. 权限不来自模型或 Prompt
 
 **选择：** 模型只能提出 `ToolRequest`。真正执行必须经过：
@@ -138,6 +145,10 @@ Tool；返回后保存 completed/failed。
 **代价：** 无法并行读取多个文件，长任务吞吐量不是 P1 的优化目标。
 
 **得到什么：** 每次模型调用、Policy 决定、ToolResult、usage 和 Artifact 都能回到同一条 Run 记录。
+
+**进程退出证据：** K1-K6 用独立子进程在 requested/started、`os.replace` 前后、SQLite transaction 和
+Model started 边界直接退出。父进程只用重开的 SQLite、文件与新 CLI 进程判断。K4 明确展示“文件已变，
+但 committed fact 仍是 Tool RUNNING”，因此 P1 不补成功、不构造 Artifact，也不重试。
 
 ## 8. timeout 不会自动撤销或重试副作用
 

--- a/site/src/content/docs/zh-cn/development/agent-loop.md
+++ b/site/src/content/docs/zh-cn/development/agent-loop.md
@@ -34,7 +34,7 @@ EventStore 中的最新事实
 | `domain/run_events.py` | v1-v4 payload registry；v4 RunCreated 携带 fingerprint，其余 v4 复用 v2 shape |
 | `domain/fingerprints.py` | 有界的 Policy、Tool 与 Run contract identity Value Objects |
 | `domain/tools.py` | 原始/规范化请求、Policy 决定、是否到达 adapter 和 ToolResult 的执行记录 |
-| `runtime/context.py` | 只从已提交 v2 Event 构造 exact ModelRequest |
+| `runtime/context.py` | 从已提交的 v2-shaped Activity Event 构造 exact ModelRequest；当前新 Run 使用 schema v4 |
 | `runtime/model_stream.py` | 有界组装 text delta、Tool call 和唯一 completion |
 | `runtime/pricing.py` | input/output 分别向上取整的整数 micro-USD 估算 |
 | `runtime/fingerprints.py` | 对可信注册信息做 canonical JSON + SHA-256，不读取 adapter 状态 |
@@ -66,7 +66,7 @@ PreparedToolRequest、PolicyDecision、是否真正进入 adapter，以及完整
 Reducer 继续只读取 v1-v4 共有的状态字段，所以 projection schema 不需要 migration。解析 Event 时会
 把冻结 JSON 容器还原成普通 JSON，再按事件类型和 schema version 严格校验。
 
-## 三个容易改坏的边界
+## 五个容易改坏的边界
 
 第一，Provider 和 Tool 只能在 started Event 提交成功后调用。任何 append 失败都原样向上返回；Loop
 不会再追加一个“看起来更完整”的失败 Event，因为事实边界本身已经不可信。
@@ -77,8 +77,10 @@ prepare、Policy、timeout、adapter 调用和输出检查只存在一份。Agen
 第三，调用者取消时 `CancelledError` 原样传播。模型或 Tool Activity 可能保持 RUNNING；P1 不
 添加恢复、自动 retry 或 `UNKNOWN` 来掩盖这个事实。
 
-第四，同一个 ToolCallRequested v2 与 terminal v2 必须包含值相等的原始 ToolRequest。这个检查读取
-Event 历史，不给 Run/Activity projection 添加 v2 专属字段，所以 v1/v2 仍得到相同 projection。
+第四，同一个版本中的 ToolCallRequested 与 v2-shaped terminal evidence 必须包含值相等的原始
+ToolRequest。当前 schema v2、v3、v4 都执行这条检查。Reducer 依据解析后的 payload shape 判断，避免
+新增复用相同 shape 的版本时漏掉校验；检查仍只读取 Event 历史，不给 Run/Activity projection 添加
+版本专属字段。
 
 第五，`ErrorInfo.retryable` 与 `ToolRetrySafety` 只保留来源观测和 Tool contract 声明。AgentLoop 不根据
 它们启动第二次调用。未来的恢复必须建立新的 Attempt 与 RecoveryDecision，不能在当前 Loop 增加隐藏

--- a/site/src/content/docs/zh-cn/development/agent-loop.md
+++ b/site/src/content/docs/zh-cn/development/agent-loop.md
@@ -1,11 +1,13 @@
 ---
-title: F-0016 有界 Agent Loop 实现导读
-description: 找到 ContextBuilder、v2 Event、串行协调器、费用估算和固定任务测试。
+title: 有界 Agent Loop 与 Run contract identity 实现导读
+description: 找到 ContextBuilder、v4 RunCreated、串行协调器、费用估算和 crash observability 测试。
 bearStatus: implemented
 sourceRefs:
   - F-0016
   - PLAN-F-0016
   - ADR-0013
+  - F-0018
+  - ADR-0016
 ---
 
 阅读 F-0016 时，先跟 `AgentLoop.run(RunInput)`，不要从某个模型或文件 adapter 倒推。Loop 只负责
@@ -29,20 +31,28 @@ EventStore 中的最新事实
 | 位置 | 责任 |
 |---|---|
 | `domain/agent.py` | AgentConfig、版本化定价、Context 报告、Run 输入和终态结果 |
-| `domain/run_events.py` | 同名 Event 的 v2 payload；v1 继续原样解析和重放 |
+| `domain/run_events.py` | v1-v4 payload registry；v4 RunCreated 携带 fingerprint，其余 v4 复用 v2 shape |
+| `domain/fingerprints.py` | 有界的 Policy、Tool 与 Run contract identity Value Objects |
 | `domain/tools.py` | 原始/规范化请求、Policy 决定、是否到达 adapter 和 ToolResult 的执行记录 |
 | `runtime/context.py` | 只从已提交 v2 Event 构造 exact ModelRequest |
 | `runtime/model_stream.py` | 有界组装 text delta、Tool call 和唯一 completion |
 | `runtime/pricing.py` | input/output 分别向上取整的整数 micro-USD 估算 |
+| `runtime/fingerprints.py` | 对可信注册信息做 canonical JSON + SHA-256，不读取 adapter 状态 |
 | `runtime/tool_executor.py` | `execute` 与 `execute_recorded` 汇合到同一个私有执行路径 |
 | `application/agent_loop.py` | 保存边界、串行调度、终止和安全失败 |
 | `evals/p1/` | 五个版本化任务定义与 workspace fixture |
 
-## v2 Event 保存什么
+## v4 RunCreated 怎样复用 v2 Activity 事实
 
-新 Run 全部写 schema version 2，SQLite 表结构不变。RunCreated 保存目标、预算和非敏感 AgentConfig
-快照；Model requested 保存 exact request 和 Context 报告；Model completed 保存 assistant Message、
+F-0018 以后，新 Run 全部写 schema version 4，SQLite 表结构不变。RunCreated v4 保存目标、预算、
+非敏感 AgentConfig、可选 Provider 选择和 `RunFingerprint`。其余 v4 Event 复用 v2 payload shape：
+Model requested 保存 exact request 和 Context 报告；Model completed 保存 assistant Message、
 Provider request ID、实际模型、finish reason、usage 和费用估算。
+
+`RunFingerprint` 由 bootstrap 使用 package version、`FixedToolPolicy.fingerprint` 与
+`ToolRegistry.specs` 构造，再作为 BearAgent domain 类型注入 AgentLoop。Loop 不读取包元数据、文件路径
+或具体 Policy 实现，也不再包含“没有 Provider 写 v2、有 Provider 写 v3”的新 Run 分支。旧 v1-v3
+parser 永久保留；query 只能从 RunCreated Event 读取 fingerprint，不能用当前 Registry 反推历史。
 
 Tool requested 保存模型提出的原始 ToolRequest。Tool completed/failed 保存可用的
 PreparedToolRequest、PolicyDecision、是否真正进入 adapter，以及完整 ToolResult。`workspace.write`
@@ -53,7 +63,7 @@ PreparedToolRequest、PolicyDecision、是否真正进入 adapter，以及完整
 模型协议失败。若 Tool 已执行但完整执行记录过大，Loop 保存 `persistence_truncated=true` 的有限失败
 记录，保留原始请求和 `reached_adapter`，随后终止 Run，不把可能已经发生的副作用自动重试。
 
-Reducer 继续只读取 v1/v2 共有的状态字段，所以 projection schema 不需要 migration。解析 Event 时会
+Reducer 继续只读取 v1-v4 共有的状态字段，所以 projection schema 不需要 migration。解析 Event 时会
 把冻结 JSON 容器还原成普通 JSON，再按事件类型和 schema version 严格校验。
 
 ## 三个容易改坏的边界
@@ -64,17 +74,22 @@ Reducer 继续只读取 v1/v2 共有的状态字段，所以 projection schema �
 第二，ToolExecutor 的两个公共入口只决定返回 `ToolResult` 还是完整执行记录。lookup、输入限制、
 prepare、Policy、timeout、adapter 调用和输出检查只存在一份。Agent Loop 不能直接调用具体 Tool。
 
-第三，调用者取消时 `CancelledError` 原样传播。模型或 Tool Activity 可能保持 RUNNING；F-0016 不
+第三，调用者取消时 `CancelledError` 原样传播。模型或 Tool Activity 可能保持 RUNNING；P1 不
 添加恢复、自动 retry 或 `UNKNOWN` 来掩盖这个事实。
 
 第四，同一个 ToolCallRequested v2 与 terminal v2 必须包含值相等的原始 ToolRequest。这个检查读取
 Event 历史，不给 Run/Activity projection 添加 v2 专属字段，所以 v1/v2 仍得到相同 projection。
+
+第五，`ErrorInfo.retryable` 与 `ToolRetrySafety` 只保留来源观测和 Tool contract 声明。AgentLoop 不根据
+它们启动第二次调用。未来的恢复必须建立新的 Attempt 与 RecoveryDecision，不能在当前 Loop 增加隐藏
+retry 分支。
 
 ## 从哪里看测试
 
 - `tests/unit/test_context_builder.py`：固定层、Tool schema、完整交互组和截断；
 - `tests/unit/test_agent_loop.py`：文本结束、多 Tool、Tool 失败、预算和协议失败；
 - `tests/recovery/test_agent_loop_boundaries.py`：每个外部调用前后的 append 故障与取消；
+- `tests/recovery/test_crash_observability.py`：K1-K6 子进程退出、SQLite 重开、文件 oracle、CLI 与调用次数；
 - `tests/security/test_agent_loop.py`：原始异常脱敏和模型不能扩大 Tool/Policy 权限；
 - `tests/evals/test_p1_agent_loop_tasks.py`：五个任务分别跑内存与 SQLite Store；
 - `tests/integration/test_tool_executor.py`：记录式入口与旧入口共享执行行为。

--- a/site/src/content/docs/zh-cn/development/index.md
+++ b/site/src/content/docs/zh-cn/development/index.md
@@ -9,6 +9,7 @@ sourceRefs:
   - F-0016
   - F-0005
   - F-0017
+  - F-0018
 ---
 
 开发者文档不复制 Spec，也不把每个目录重新列一遍。它负责回答三个问题：代码从哪里进入、关键
@@ -58,11 +59,11 @@ RunState。第三遍再读安全测试，确认你看到的是受测试约束的
 - [F-0001：内部数据类型](/zh-cn/development/domain-contracts/)——ID、Message、Error、Event 以及模型 adapter 的翻译边界；
 - [F-0002：状态和预算](/zh-cn/development/run-reducer-and-budgets/)——具体 Event、Reducer、预算检查和修改顺序；
 - [F-0003：SQLite EventStore](/zh-cn/development/sqlite-event-store/)——transaction、migration、projection 和故障测试；
-- [F-0004/F-0017：ModelProvider 与协议 adapter](/zh-cn/development/model-provider/)——显式 protocol factory、三种流式翻译、Event v3 和 live gate；
+- [F-0004/F-0017：ModelProvider 与协议 adapter](/zh-cn/development/model-provider/)——显式 protocol factory、三种流式翻译、Provider selection 和 live gate；
 - [F-0006：Tool 执行边界](/zh-cn/development/tool-execution-boundary/)——Registry、参数准备、默认拒绝 Policy 和统一 Executor；
 - [F-0007：workspace 只读 Tool](/zh-cn/development/workspace-read-tools/)——跨平台路径边界、list/read/search 和安全测试；
 - [F-0008：原子输出与 Artifact](/zh-cn/development/atomic-output-artifacts/)——同目录暂存、原子提交、结果元数据和故障窗口；
-- [F-0016：有界 Agent Loop](/zh-cn/development/agent-loop/)——Context、v2 Event、串行模型/Tool 调度、故障窗口和固定任务；
+- [F-0016/F-0018：有界 Agent Loop 与证据边界](/zh-cn/development/agent-loop/)——Context、RunCreated v4、contract fingerprint、串行调度和 K1-K6；
 - [F-0005：生产 CLI 与查询](/zh-cn/development/run-cli/)——Run profile、composition root、inspect/events、JSON 契约和失败边界；
 - [Feature 完成时怎样更新文档](/zh-cn/development/feature-documentation/)——哪些事实写在 `docs/`，哪些解释写在站点；
 - [本地运行文档站](/zh-cn/guides/local-docs/)——安装、构建和检查 Starlight。

--- a/site/src/content/docs/zh-cn/development/model-provider.md
+++ b/site/src/content/docs/zh-cn/development/model-provider.md
@@ -1,6 +1,6 @@
 ---
 title: ModelProvider 与三种协议 adapter 实现导读
-description: 从 config.json 走到 protocol factory、流事件翻译、Event v3 和 live gate。
+description: 从 config.json 走到 protocol factory、流事件翻译、v4 Provider selection 和 live gate。
 bearStatus: implemented
 sourceRefs:
   - F-0004
@@ -8,6 +8,7 @@ sourceRefs:
   - F-0017
   - ADR-0015
   - PLAN-F-0017
+  - F-0018
 ---
 
 一次 `bearagent run` 不会把“OpenAI 兼容”当成足够的配置。它先从 RunProfile 取得
@@ -16,6 +17,8 @@ sourceRefs:
 
 F-0004 建立 port 与首个 Responses adapter；F-0017 增加可复用配置、Chat Completions、Anthropic
 Messages、Event v3 和默认关闭的真实模型验收入口。三个 protocol 是产品边界，厂商名不是分支条件。
+F-0018 的新 Run 改写 v4，在同一个 RunCreated payload 中保留这份 Provider selection 并增加 contract
+fingerprint；v3 作为历史读取格式不变。
 
 ## 一次选择怎样进入模型调用
 
@@ -80,9 +83,9 @@ ToolCall 之前结束、完成后又出现关键事件、未知关键 event 或 
 防止 key 出现在配置 model 的 repr/JSON；factory 只在创建选定 adapter 时解封。
 
 Bootstrap 从默认模型构造 `unpriced` 的 `AgentConfig`；真实 gate 单独注入 pricing snapshot。新 Run 使用
-RunCreated v3 保存 `provider_id`、由非密钥 Provider/model 字段计算的 config version、protocol、配置
-model 和 pricing version。它不保存 base URL 或 key。旧 RunCreated v1/v2 与 RunProfile v1 继续可读，SQLite
-不需要新增表或列。
+RunCreated v4 保存 `provider_id`、由非密钥 Provider/model 字段计算的 config version、protocol、配置
+model、pricing version 和 contract fingerprint。它不保存 base URL 或 key。旧 RunCreated v1/v2/v3 与
+RunProfile v1 继续可读，SQLite 不需要新增表或列。
 
 缺少、空白或非法 key 会在数据库和 Run 创建前返回安全的 `invalid_input`。有效 key 不进入
 AgentConfig、Event、SQLite、CLI 输出或 live report。零预算仍会在创建 SDK client 前停止。
@@ -104,7 +107,7 @@ Attempt 的恢复与重试语义。
 - `tests/contract/test_anthropic_messages_provider.py`：Messages 生命周期、tool JSON 与 cached usage；
 - `tests/unit/test_provider_config.py`、`tests/unit/test_run_profile_versions.py`：catalog/profile 边界；
 - `tests/unit/test_provider_composition.py`：三种 protocol 的唯一 factory 选择与延迟缺 key；
-- `tests/integration/test_provider_selection_events.py`：RunCreated v3、查询与旧 Event 兼容；
+- `tests/integration/test_provider_selection_events.py`：RunCreated v4、fingerprint、SQLite 重开与旧 Event 兼容；
 - `tests/unit/test_p1_live_eval.py`、`tests/integration/test_p1_live_eval.py`：默认关闭的 preflight、
   五个隔离任务、SQLite 重开、rubric、canary 和脱敏 report；
 - `tests/architecture/test_import_boundaries.py`：SDK 不能进入 core。

--- a/site/src/content/docs/zh-cn/development/run-cli.md
+++ b/site/src/content/docs/zh-cn/development/run-cli.md
@@ -8,6 +8,8 @@ sourceRefs:
   - ADR-0014
   - F-0017
   - ADR-0015
+  - F-0018
+  - ADR-0016
 ---
 
 修改 `bearagent run` 时，先沿着 `interfaces -> bootstrap/application -> ports -> adapters` 阅读。CLI 只
@@ -20,7 +22,7 @@ sourceRefs:
 | `domain/agent.py` | 严格、非敏感的 RunProfile v1/v2 |
 | `configuration.py` | config v1 的 Provider 列表、HTTPS/base URL、直接 key、SecretStr、无 pricing 和条目上限 |
 | `domain/providers.py` | `ModelProtocol` 与非敏感 `ProviderSelection` |
-| `domain/queries.py` | RunInspection、Provider 选择与有界 EventPage |
+| `domain/queries.py` | RunInspection、Provider/contract identity 与有界 EventPage |
 | `application/run_queries.py` | 只通过 EventStore 查询 projection、Event 和 Artifact |
 | `bootstrap.py` | 读取 profile/catalog，按显式 protocol 组装 adapter、SQLite、Tools、Policy 与 AgentLoop |
 | `interfaces/cli/contracts.py` | version 1 Run/inspect/events result 与 safe error envelope |
@@ -49,8 +51,9 @@ point、替换竞态、非法 UTF-8、未知字段、非法 URL/key 和未知字
 ## query service 为什么不写 SQL
 
 `RunQueryService.inspect` 先取得 RunState，再以最多 1,000 条一页扫描 Event，总量最多 10,000 条。
-每页必须属于同一个 Run，sequence 连续并且不超过 projection 的 `last_sequence`。RunCreated v3
-经过正式 parser 后提供安全 Provider 选择；v2 ToolCallCompleted payload 才允许提取
+每页必须属于同一个 Run，sequence 连续并且不超过 projection 的 `last_sequence`。RunCreated v4
+经过正式 parser 后提供安全 Provider 选择与 RunFingerprint；legacy v1-v3 保持缺失或原有 Provider
+选择。v2 shape 的 ToolCallCompleted payload 才允许提取
 `workspace.write` Artifact。
 
 `events` 同样先读取 projection，之后只查询当时已提交的有限前缀。返回的 EventPage 验证 Run ID、

--- a/site/src/content/docs/zh-cn/development/run-reducer-and-budgets.md
+++ b/site/src/content/docs/zh-cn/development/run-reducer-and-budgets.md
@@ -4,7 +4,9 @@ description: 具体 Event、Reducer、预算检查的调用关系、修改顺序
 bearStatus: implemented
 sourceRefs:
   - F-0002
+  - F-0018
   - ADR-0009
+  - ADR-0016
   - domain schema snapshot
 ---
 
@@ -29,9 +31,10 @@ domain/schema.py       把公开数据结构加入兼容性快照
 
 1. 根据 `event_type` 和 `schema_version` 找到精确 payload 类型；
 2. 确认首条 Event、Run ID 和连续 sequence；
-3. 确认当前 Run/Activity 允许这个转换，并且 ID 没有重复；
-4. 如果是新的模型或工具请求，先检查预算；
-5. 创建新的冻结状态，旧状态保持不变。
+3. 对 v2-shaped Tool terminal evidence，确认完整 execution 使用的原始请求与同版本 requested Event 相同；
+4. 确认当前 Run/Activity 允许这个转换，并且 ID 没有重复；
+5. 如果是新的模型或工具请求，先检查预算；
+6. 创建新的冻结状态，旧状态保持不变。
 
 未知类型、未知版本、sequence 缺口、跨 Run 和非法转换都会被拒绝。公开错误只保留稳定 code、
 message 和安全详情，Pydantic 的原始校验文本只作为 Python 异常原因保留。
@@ -40,6 +43,7 @@ message 和安全详情，Pydantic 的原始校验文本只作为 Python 异常�
 
 - 如果 Event 会改变 P1 状态，同时修改 payload、registry、Reducer、测试和 schema 快照；
 - 不兼容的 payload 使用新版本，不要直接改变 v1 的含义；
+- 新版本如果复用已有 payload shape，跨 Event 校验应按解析后的类型生效，不要维护容易漏项的版本号清单；
 - 模型完成或失败时，保留 Provider 已报告的实际 token 和费用，即使已经超限；
 - 模型和工具数据不能提高 `RunCreated` 中的限制；
 - pause、cancel、Attempt、`UNKNOWN` 和 Approval 属于后续阶段，不要提前塞进 P1 状态。

--- a/site/src/content/docs/zh-cn/development/sqlite-event-store.md
+++ b/site/src/content/docs/zh-cn/development/sqlite-event-store.md
@@ -4,6 +4,8 @@ description: 跟随 Event 从校验、transaction、Reducer 到 projection，理
 bearStatus: implemented
 sourceRefs:
   - F-0003
+  - F-0018
+  - ADR-0016
   - SQLite documentation
 ---
 
@@ -80,6 +82,11 @@ get_run(run_id)           读取已验证的当前 projection
 写入触发完整性错误，它报告普通持久化失败；如果 Event 自己与已提交事实冲突，则报告
 `EventStoreConflictError`。两种情况对调用方的处理含义不同。
 
+F-0018 的 K5 会建立一个只在 pending Activity projection 写入时失败的 SQLite trigger。Event insert
+已经执行，但 projection 写入中止；transaction rollback 后换一个新的 Store 重开，Event 与 projection
+都停在之前的 `RunStarted`。CLI 也只能看到 sequence 2。这不是 mock 返回值，而是对现有 transaction
+边界的故障注入。
+
 ## 为什么每次操作都新开 connection
 
 标准库 `sqlite3` 是同步接口，公开方法用 `asyncio.to_thread` 避免阻塞事件循环。每次操作在工作线程
@@ -123,6 +130,7 @@ transaction，内存实现可以复制字典，但两者对合法与非法输入
 |---|---|
 | `tests/contract/test_event_store_contract.py` | 两种 store 是否保持同一使用方式 |
 | `tests/integration/test_sqlite_event_store.py` | WAL、重开、并发同 sequence、projection rollback、表和 sequence 损坏 |
+| `tests/recovery/test_crash_observability.py` | K1-K6 重开查询；K5 证明 Event/projection 没有部分提交 |
 | `tests/security/test_sqlite_event_store.py` | SQL-like payload 只作为数据、错误不泄漏内容和路径、锁超时、超大 payload |
 
 ```powershell

--- a/site/src/content/docs/zh-cn/development/sqlite-event-store.md
+++ b/site/src/content/docs/zh-cn/development/sqlite-event-store.md
@@ -74,9 +74,11 @@ get_run(run_id)           读取已验证的当前 projection
 3. `_load_run_projection` 恢复之前的 `RunState`；
 4. `_maximum_sequence` 检查 Event 是否从 1 连续到最大 sequence；
 5. `_validate_projection_sequence` 确认 projection 的 `last_sequence` 与事实相同；
-6. `reduce_event` 拒绝非法新 Event 或生成新状态；
-7. 插入 Event，再 upsert Run projection 并重写该 Run 的 Activity projection；
-8. 最后 commit。
+6. `validate_event_history` 核对需要读取旧 payload 的不变量，例如 v2/v3/v4 Tool terminal evidence
+   不能替换 requested Event 的原始 ToolRequest；
+7. `reduce_event` 拒绝非法新 Event 或生成新状态；
+8. 插入 Event，再 upsert Run projection 并重写该 Run 的 Activity projection；
+9. 最后 commit。
 
 任何一步失败都会 rollback。代码特意记录 `event_inserted`：如果 Event insert 已成功、后续 projection
 写入触发完整性错误，它报告普通持久化失败；如果 Event 自己与已提交事实冲突，则报告
@@ -119,7 +121,8 @@ F-0018 的 K5 会建立一个只在 pending Activity projection 写入时失败�
 ## Contract test 怎样帮助理解两个实现
 
 `tests/contract/test_event_store_contract.py` 把相同用例分别跑在 `InMemoryEventStore` 和
-`SqliteEventStore` 上。它检查合法追加、顺序冲突、全局 Event ID 冲突和有界查询。
+`SqliteEventStore` 上。它检查合法追加、顺序冲突、全局 Event ID 冲突、有界查询，以及各个共享
+execution evidence shape 的 schema version 都拒绝矛盾的原始 ToolRequest。
 
 这说明 port 的意义不是“定义了几个方法”，而是调用方能依赖的可观察行为。SQLite 可以使用 SQL
 transaction，内存实现可以复制字典，但两者对合法与非法输入必须给出相同结论。

--- a/site/src/content/docs/zh-cn/development/tool-execution-boundary.md
+++ b/site/src/content/docs/zh-cn/development/tool-execution-boundary.md
@@ -5,8 +5,11 @@ bearStatus: implemented
 sourceRefs:
   - F-0006
   - PLAN-F-0006
+  - F-0016
+  - F-0018
   - ADR-0004
   - ADR-0005
+  - ADR-0016
 ---
 
 F-0006 把原来的 P0 FakeTool 占位升级为一条可复用的执行路径。它不实现真实文件访问，也不写 Event。
@@ -15,7 +18,7 @@ F-0006 把原来的 P0 FakeTool 占位升级为一条可复用的执行路径。
 ## 请求从哪里经过
 
 ```text
-ToolExecutor.execute(request)
+ToolExecutor.execute_recorded(request)
   -> ToolRegistry.get(name)
   -> Tool.prepare(request)
   -> ToolPolicy.evaluate(spec, prepared_request)
@@ -38,7 +41,11 @@ FakeTool 检查了这个顺序。
 | `src/bearagent/runtime/tool_executor.py` | 调用顺序、timeout、取消、输出上限和错误转换 |
 | `src/bearagent/adapters/testing/tools.py` | 不访问外部环境的确定性 FakeTool |
 
-## 修改时先守住三个不变量
+Registry 构造时只读取每个 Tool 的一次 `ToolSpec`，再把这份冻结值同时用于精确名称索引、稳定排序、
+Provider schema、Policy 和 Run fingerprint。这样即使 adapter 把 `spec` 写成动态属性，也不能让查找名称
+和真正受检查、被哈希的 contract 分叉。
+
+## 修改时先守住四个不变量
 
 第一，`prepare` 必须是纯检查。未来路径规范化可以放这里，实际读取或写入不可以。
 
@@ -47,6 +54,9 @@ FakeTool 检查了这个顺序。
 
 第三，所有执行都经过 `ToolExecutor`。具体 Tool 不应由 Agent Loop 或 adapter 直接调用，否则 timeout、
 输出上限和默认拒绝会出现旁路。
+
+第四，Registry 的注册快照只能读取一次 `ToolSpec`。后续执行和 fingerprint 必须共享这份值，不能再次
+向 Tool 查询一份可能不同的声明。
 
 ## 测试从哪里看
 
@@ -59,5 +69,6 @@ FakeTool 检查了这个顺序。
 
 F-0007 的三个只读 Tool 和 F-0008 的原子写入 Tool 已运行同一条 Executor 路径。具体路径检查见
 [F-0007 workspace 只读 Tool 实现导读](/zh-cn/development/workspace-read-tools/)，提交点和 Artifact 见
-[F-0008 原子输出与 Artifact 实现导读](/zh-cn/development/atomic-output-artifacts/)。F-0016 接线时，只调用
-`ToolExecutor.execute`，并负责把前后状态写成 Tool Activity Event。
+[F-0008 原子输出与 Artifact 实现导读](/zh-cn/development/atomic-output-artifacts/)。F-0016 接线后，
+AgentLoop 调用 `ToolExecutor.execute_recorded`，把原始/规范化请求、Policy 决定、adapter 到达标志和结果
+写入 Tool Activity Event；旧的 `execute` 仍复用同一私有执行路径，只返回其中的 `ToolResult`。

--- a/site/src/content/docs/zh-cn/guides/cli.md
+++ b/site/src/content/docs/zh-cn/guides/cli.md
@@ -7,6 +7,8 @@ sourceRefs:
   - F-0017
   - ADR-0014
   - ADR-0015
+  - F-0018
+  - ADR-0016
   - cli schema snapshot
 ---
 
@@ -149,8 +151,8 @@ base URL、workspace 绝对路径或数据库路径。
 
 BearAgent 故意不提供 `--api-key`。新配置把 key 只写在被 Git 忽略的本机 `data/config.json` 中；不要把
 凭据写进 RunProfile、objective、命令参数、Event、Git、截图或 issue。Config loader 使用 `SecretStr`
-遮蔽 key，Event v3 只保存 `provider_id`、非密钥 `config_version`、protocol、model 和 pricing version，
-不保存 endpoint 或 key。
+遮蔽 key。新 Run 的 Event v4 保存 `provider_id`、非密钥 `config_version`、protocol、model、pricing
+version 与声明的 Policy/Tool contract fingerprint，不保存 endpoint、key 或完整 Policy 配置。
 
 Config v1 缺少、空白或非法 key 时，会在数据库和 Run 创建前返回 `invalid_input`。旧 RunProfile v1 仍
 为兼容已有配置保留：它只支持 legacy OpenAI Responses 路径，并继续读取 `OPENAI_API_KEY` 与可选的

--- a/site/src/content/docs/zh-cn/learn/configure-model-service.md
+++ b/site/src/content/docs/zh-cn/learn/configure-model-service.md
@@ -6,6 +6,7 @@ sourceRefs:
   - F-0017
   - ADR-0015
   - F-0005
+  - F-0018
 ---
 
 你不需要为每个问题生成一份 Provider JSON。下面两次运行复用同一份 `config.json` 和 RunProfile；
@@ -110,8 +111,9 @@ uv run bearagent run events <run-id> --json
 
 只有临时使用其他配置时，才需要用 `--config` 或 `--profile` 覆盖默认路径。
 
-缺少、空白或非法 key 时，config 会在创建数据库和 Run 前失败。v2 Run 只用 Event schema v3 保存
-`provider_id`、自动计算的 `config_version` 和 `protocol`，不会保存 base URL、key 或 HTTP header。
+缺少、空白或非法 key 时，config 会在创建数据库和 Run 前失败。新 Run 使用 Event schema v4 保存
+`provider_id`、自动计算的 `config_version`、`protocol` 与可信 contract fingerprint，不会保存 base
+URL、key 或 HTTP header。F-0017 引入的 Event v3 继续可读。
 用户不需要手工填写 `config_version`；非密钥 Provider/model 字段变化时，它会自动变化。
 
 Version 1 profile 仍可读取，并映射到 legacy `openai_responses` 与 `OPENAI_API_KEY`。这是已有配置的

--- a/site/src/content/docs/zh-cn/learn/run-inspect-events.md
+++ b/site/src/content/docs/zh-cn/learn/run-inspect-events.md
@@ -8,6 +8,8 @@ sourceRefs:
   - F-0016
   - F-0017
   - ADR-0015
+  - F-0018
+  - ADR-0016
 ---
 
 你运行一个文件任务后，最先要回答的不是“模型说了什么”，而是三个更具体的问题：这次 Run 的 ID
@@ -29,8 +31,9 @@ bearagent run events <run-id> --after-sequence 0 --limit 100
 ```mermaid
 flowchart TB
     C["CLI 校验 objective 和路径"] --> B["bootstrap 读取 Run profile 和 BearAgent config"]
-    B --> G["按显式 protocol 组装一个 Provider、SQLite、Policy 和 workspace Tools"]
-    G --> L["AgentLoop 保存并执行 Run"]
+    B --> G["按显式 protocol 组装 Provider、SQLite、Policy 和 workspace Tools"]
+    G --> F["根据可信注册信息构造 RunFingerprint"]
+    F --> L["AgentLoop 保存并执行 Run"]
     L --> R["RunResult"]
     R --> H["human 或 JSON 输出"]
     D["inspect / events"] --> Q["application query service"]
@@ -65,9 +68,14 @@ RunStarted 和 `budget_exhausted` RunFailed；SDK client 不会创建，模型�
 ## inspect 与 events 看的是不同层次
 
 `inspect` 返回 Reducer 已计算出的完整 RunState，包括预算、usage、Activity、terminal Error 和最后
-sequence。新 Run 还显示 RunCreated v3 保存的 `provider_id`、config version、protocol、配置 model 和
-pricing version（普通 Run 为 `unpriced`），不显示 base URL 或 key。它也会分页扫描已提交的 v2 Tool completed Event，从
-`workspace.write` 结果重建 Artifact 元数据。如果 Event 总量超过可信上限，命令会明确失败，不会把不完整 Artifact 列表说成完整结果。
+sequence。新 Run 还显示 RunCreated v4 保存的 `provider_id`、config version、protocol，以及
+BearAgent/Policy/Tool contract fingerprints，不显示 base URL、key 或完整 Policy 配置。Tool fingerprint
+中的 `spec_version` 标识 schema 之外的 prepare/validation contract，SHA-256 标识完整注册时 ToolSpec。
+它们是声明身份，不是 Git 快照、权限或恢复证据。旧 v1-v3 Run 没有 fingerprint 时返回缺失，不会按
+当前配置伪造历史值。
+
+Query 还会分页扫描已提交的 Tool completed Event，从 `workspace.write` 结果重建 Artifact 元数据。如果
+Event 总量超过可信上限，命令会明确失败，不会把不完整 Artifact 列表说成完整结果。
 
 `events` 返回一页不可变事实，并带回 `next_after_sequence` 和 `has_more`。默认 human 输出每条只显示
 sequence、时间、类型和 schema version，不显示 payload。`--json` 是显式完整导出，可能包含用户目标、
@@ -79,7 +87,15 @@ sequence、时间、类型和 schema version，不显示 payload。`--json` 是�
 PENDING/RUNNING Activity；它不会猜测成功，也不会自动追加 RunFailed。若文件已经写成，但
 ToolCallCompleted 没有提交，查询也不会从文件系统反推一个 Artifact。
 
-自动恢复、retry、Attempt、Receipt 和 `UNKNOWN` 属于 P2。F-0017 已实现默认关闭的 live runner，
+F-0018 用独立子进程把这条规则落到了六个可复现边界：Tool requested/started、`os.replace` 前后、
+Event/projection transaction 和 Model started。最容易误判的是 replace 之后：磁盘上已经是新文件，
+但最后 committed fact 仍是 `ToolCallStarted`，所以 `inspect` 只显示 RUNNING。测试随后用新 SQLite
+adapter 和新的 CLI 进程读取，并确认 Provider/Tool 调用计数没有增加。
+
+`retryable=true` 也只说明错误来源认为另一次尝试可能成功；`ToolRetrySafety` 只是 Tool 声明的粗粒度
+提示。两者都不会让 P1 Runtime 获得重试权限。
+
+自动恢复、retry、Attempt、Receipt 和 `UNKNOWN` 仍属于 P2。F-0017 已实现默认关闭的 live runner，
 真实 gate 仍必须由项目所有者确认 Provider、model、pricing snapshot 和费用上限后单独执行。2026-08-23
 的 DeepSeek V4 suite v1.1.1 已通过 5/5，因此 F-0017/P1 已关闭；runner 默认状态没有改变。
 

--- a/site/src/content/docs/zh-cn/project/milestones.md
+++ b/site/src/content/docs/zh-cn/project/milestones.md
@@ -5,6 +5,8 @@ bearStatus: mixed
 sourceRefs:
   - roadmap
   - F-0017
+  - F-0018
+  - ADR-0016
 ---
 
 BearAgent 不按“已经写了多少模块”关闭阶段。每个阶段都要在同一组仓库与本地文档任务上给用户
@@ -35,7 +37,9 @@ P1 已完成 SQLite EventStore、三种模型协议 adapter、Registry、固定 
 workspace 读写、原子 Artifact、ContextBuilder、串行 Agent Loop、`run/inspect/events`、Provider
 catalog、RunProfile v2、RunCreated v3 和默认关闭的 live runner。五个 Fake 任务与最终离线 Reality
 Check 通过；suite v1.1.1 又用 DeepSeek V4 经 production 路径完成四个普通任务与安全 canary，并生成
-脱敏 report。
+脱敏 report。F-0018 随后让新 Run 统一写 schema v4，保存声明的 Tool/Policy contract fingerprint，并用
+K1-K6 核对 hard process exit 后最后可见的 committed fact。v2-shaped Tool execution evidence 在 v2、v3、
+v4 都执行同一条原始请求一致性检查；这仍是事实完整性，不是自动恢复。
 
 P1 只保证已经保存的事实可以查看。进程退出后不会自动继续。
 

--- a/site/src/content/docs/zh-cn/project/status.md
+++ b/site/src/content/docs/zh-cn/project/status.md
@@ -15,12 +15,15 @@ sourceRefs:
   - F-0015
   - F-0005
   - F-0017
+  - F-0018
+  - ADR-0016
 ---
 
 BearAgent 已有本地 `run/inspect/events` CLI。它用 config v1 与 RunProfile v2 显式选择
 Responses、Chat Completions 或 Anthropic Messages 协议，再组装 SQLite、固定 Policy、workspace Tools
 和有界 Agent Loop。F-0017 的 suite v1.1.1 已用 DeepSeek V4 经 production composition 通过四个普通
-任务与安全 canary；脱敏 report 和最终 Reality Check 完成，因此 F-0017/P1 已关闭。
+任务与安全 canary；脱敏 report 和最终 Reality Check 完成，因此 F-0017/P1 已关闭。当前分支还用
+RunCreated v4 保存声明的 BearAgent/Policy/Tool contract identity，并完成 K1-K6 进程退出观测基线。
 
 ## 三十秒结论
 
@@ -28,6 +31,7 @@ Responses、Chat Completions 或 Anthropic Messages 协议，再组装 SQLite、
 |---|---|
 | 能在本机运行一个真实模型文件任务吗？ | 能，需要有效 config、非零预算和受限 workspace |
 | 能查询任务做过什么吗？ | 能，用 `inspect` 看状态，用 `events` 看有序事实 |
+| 能知道 Run 使用了哪版 Tool/Policy 声明吗？ | 新 Run 可以；`inspect` 显示版本和 SHA-256，legacy Run 明确缺失 |
 | 程序中断后会自动继续吗？ | 不会，P2 尚未实现 |
 | 有用户 Approval 或真正的 sandbox 吗？ | 没有，P3 尚未实现 |
 | 文档站可以查看吗？ | 可以；在本地启动开发或生产预览，仓库不负责在线部署 |
@@ -47,6 +51,7 @@ Responses、Chat Completions 或 Anthropic Messages 协议，再组装 SQLite、
 | F-0016 有界 Agent Loop | 从已提交 Event 构造 Context，串行调用模型与 Tool，保存 v2 事实；五个 Fake 任务在两种 Store 上通过 |
 | F-0005 生产 CLI 与查询 | `run/inspect/events`、严格 profile、production composition、分页查询和 human/JSON；零预算与 Provider 调用失败保留安全 terminal Run；五个任务通过真实 SQLite/Tools + Fake Provider |
 | F-0017 模型配置与 live gate | config v1、RunProfile v2、三种协议 adapter、RunCreated v3、production selector 与默认关闭的 runner；Fake 5/5 和 DeepSeek V4 live 5/5 分开验证 |
+| F-0018 evidence hardening | ToolSpec/Policy contract fingerprint、RunCreated v4、legacy v1-v3 读取、retryable 非授权语义，以及 K1-K6 SQLite/CLI crash suite |
 | F-0015 文档站 | 中文 Starlight、搜索、Mermaid、六部分学习路线、独立 CLI 手册，以及本地开发、构建和预览 |
 
 ## P1 完成证据
@@ -66,7 +71,8 @@ P1 当前怎样操作见[命令行完整使用手册](/zh-cn/guides/cli/)；执�
 
 - SQLite 可以保存 Event 和 projection，但进程重启后不会自动继续 Run；
 - `inspect/events` 只能查看已提交事实，不能 resume、retry 或修复非终态 Run；
-- RunCreated v3 只增加安全 Provider 选择；Tool 请求和 Artifact 仍随 v2 Event 写入 Store；
+- RunCreated v4 增加安全 Provider 选择与 contract fingerprint；其余 Activity 继续复用 v2 payload shape；
+- K4 即使文件已经 replace，terminal Event 缺失时仍只显示 RUNNING；当前不会 reconcile 或自动补成功；
 - 还没有用户 Approval、sandbox、服务器 API 或独立 Artifact 查询表；
 - 文档站没有自动部署 workflow，也没有绑定域名或托管平台；这不是 F-0015 的未完成项；
 - `docs.bearguin.cn` 尚未配置。如果以后需要在线托管，应另行定义部署目标和验收标准。

--- a/site/src/content/docs/zh-cn/project/status.md
+++ b/site/src/content/docs/zh-cn/project/status.md
@@ -51,7 +51,7 @@ RunCreated v4 保存声明的 BearAgent/Policy/Tool contract identity，并完�
 | F-0016 有界 Agent Loop | 从已提交 Event 构造 Context，串行调用模型与 Tool，保存 v2 事实；五个 Fake 任务在两种 Store 上通过 |
 | F-0005 生产 CLI 与查询 | `run/inspect/events`、严格 profile、production composition、分页查询和 human/JSON；零预算与 Provider 调用失败保留安全 terminal Run；五个任务通过真实 SQLite/Tools + Fake Provider |
 | F-0017 模型配置与 live gate | config v1、RunProfile v2、三种协议 adapter、RunCreated v3、production selector 与默认关闭的 runner；Fake 5/5 和 DeepSeek V4 live 5/5 分开验证 |
-| F-0018 evidence hardening | ToolSpec/Policy contract fingerprint、RunCreated v4、legacy v1-v3 读取、retryable 非授权语义，以及 K1-K6 SQLite/CLI crash suite |
+| F-0018 evidence hardening | ToolSpec/Policy contract fingerprint、RunCreated v4、legacy v1-v3 读取、v2/v3/v4 Tool evidence 一致性、retryable 非授权语义，以及 K1-K6 SQLite/CLI crash suite |
 | F-0015 文档站 | 中文 Starlight、搜索、Mermaid、六部分学习路线、独立 CLI 手册，以及本地开发、构建和预览 |
 
 ## P1 完成证据

--- a/src/bearagent/adapters/model/_openai_errors.py
+++ b/src/bearagent/adapters/model/_openai_errors.py
@@ -1,7 +1,5 @@
 """Normalize OpenAI SDK failures without retaining untrusted response data."""
 
-from collections.abc import Mapping
-
 import httpx
 from openai import (
     APIConnectionError,
@@ -91,11 +89,3 @@ def classify_openai_error(cause: BaseException) -> ModelProviderError:
         retryable=False,
         cause=cause,
     )
-
-
-def safe_openai_details(cause: BaseException) -> Mapping[str, SafeDetailValue]:
-    """Return only bounded identifiers if a future adapter needs error context."""
-    details: dict[str, SafeDetailValue] = {}
-    if request_id := safe_detail_text(getattr(cause, "request_id", None)):
-        details["request_id"] = request_id
-    return details

--- a/src/bearagent/adapters/sandbox/__init__.py
+++ b/src/bearagent/adapters/sandbox/__init__.py
@@ -1,1 +1,0 @@
-"""Sandbox adapters will be introduced in P3."""

--- a/src/bearagent/adapters/tools/workspace_list.py
+++ b/src/bearagent/adapters/tools/workspace_list.py
@@ -65,6 +65,7 @@ class WorkspaceListTool:
 
     spec = ToolSpec(
         name="workspace.list",
+        spec_version="1",
         description="List one page of direct entries in a workspace directory.",
         input_schema=_ListArguments.model_json_schema(),
         output_schema=_ListOutput.model_json_schema(),

--- a/src/bearagent/adapters/tools/workspace_read.py
+++ b/src/bearagent/adapters/tools/workspace_read.py
@@ -59,6 +59,7 @@ class WorkspaceReadTool:
 
     spec = ToolSpec(
         name="workspace.read",
+        spec_version="1",
         description="Read one bounded page of complete lines from a UTF-8 workspace file.",
         input_schema=_ReadArguments.model_json_schema(),
         output_schema=_ReadOutput.model_json_schema(),

--- a/src/bearagent/adapters/tools/workspace_search.py
+++ b/src/bearagent/adapters/tools/workspace_search.py
@@ -98,6 +98,7 @@ class WorkspaceSearchTool:
 
     spec = ToolSpec(
         name="workspace.search",
+        spec_version="1",
         description="Search for a literal string in bounded UTF-8 workspace files.",
         input_schema=_SearchArguments.model_json_schema(),
         output_schema=_SearchOutput.model_json_schema(),

--- a/src/bearagent/adapters/tools/workspace_write.py
+++ b/src/bearagent/adapters/tools/workspace_write.py
@@ -54,6 +54,7 @@ class WorkspaceWriteTool:
 
     spec = ToolSpec(
         name="workspace.write",
+        spec_version="1",
         description="Atomically write one bounded UTF-8 text file below outputs/.",
         input_schema=_WriteArguments.model_json_schema(),
         output_schema=_WriteOutput.model_json_schema(),

--- a/src/bearagent/application/agent_loop.py
+++ b/src/bearagent/application/agent_loop.py
@@ -10,6 +10,7 @@ from bearagent.domain.agent import RunInput, RunResult
 from bearagent.domain.artifacts import Artifact, artifact_from_tool_result_data
 from bearagent.domain.errors import ErrorCategory, ErrorCode, ErrorInfo
 from bearagent.domain.events import Event
+from bearagent.domain.fingerprints import RunFingerprint
 from bearagent.domain.ids import (
     ActivityId,
     CausationId,
@@ -24,14 +25,12 @@ from bearagent.domain.messages import Message, TextPart, ToolCallPart
 from bearagent.domain.model import ModelFinishReason, ModelRequest
 from bearagent.domain.providers import ProviderSelection
 from bearagent.domain.run_events import (
-    RUN_EVENT_SCHEMA_VERSION_V2,
-    RUN_EVENT_SCHEMA_VERSION_V3,
+    RUN_EVENT_SCHEMA_VERSION_V4,
     ModelCallCompletedPayloadV2,
     ModelCallFailedPayloadV2,
     ModelCallRequestedPayloadV2,
     ModelCallStartedPayloadV2,
-    RunCreatedPayloadV2,
-    RunCreatedPayloadV3,
+    RunCreatedPayloadV4,
     RunFailedPayloadV2,
     RunStartedPayloadV2,
     RunSucceededPayloadV2,
@@ -76,6 +75,7 @@ class AgentLoop:
         model_provider: ModelProvider,
         event_store: EventStore,
         tool_executor: ToolExecutor,
+        run_fingerprint: RunFingerprint,
         context_builder: ContextBuilder | None = None,
         clock: Clock | None = None,
         id_generator: IdGenerator | None = None,
@@ -88,11 +88,7 @@ class AgentLoop:
         self._context_builder = ContextBuilder() if context_builder is None else context_builder
         self._clock = SystemClock() if clock is None else clock
         self._provider_selection = provider_selection
-        self._event_schema_version = (
-            RUN_EVENT_SCHEMA_VERSION_V2
-            if provider_selection is None
-            else RUN_EVENT_SCHEMA_VERSION_V3
-        )
+        self._run_fingerprint = run_fingerprint
         self._id_generator = Uuid4IdGenerator() if id_generator is None else id_generator
 
     async def run(self, run_input: RunInput, *, run_id: RunId | None = None) -> RunResult:
@@ -104,21 +100,13 @@ class AgentLoop:
         # identifier carries no authority; all execution still starts at append.
         run_id = self._id_generator.new(RunId) if run_id is None else run_id
         correlation_id = self._id_generator.new(CorrelationId)
-        run_created = (
-            RunCreatedPayloadV2(
-                session_id=run_input.session_id,
-                budget_limits=run_input.budget_limits,
-                objective=run_input.objective,
-                agent_config=run_input.agent_config,
-            )
-            if self._provider_selection is None
-            else RunCreatedPayloadV3(
-                session_id=run_input.session_id,
-                budget_limits=run_input.budget_limits,
-                objective=run_input.objective,
-                agent_config=run_input.agent_config,
-                provider_selection=self._provider_selection,
-            )
+        run_created = RunCreatedPayloadV4(
+            session_id=run_input.session_id,
+            budget_limits=run_input.budget_limits,
+            objective=run_input.objective,
+            agent_config=run_input.agent_config,
+            run_fingerprint=self._run_fingerprint,
+            provider_selection=self._provider_selection,
         )
         state = await self._append(
             None,
@@ -533,7 +521,7 @@ class AgentLoop:
             run_id=run_id,
             sequence=1 if state is None else state.last_sequence + 1,
             event_type=event_type,
-            schema_version=self._event_schema_version,
+            schema_version=RUN_EVENT_SCHEMA_VERSION_V4,
             occurred_at=self._clock.now(),
             causation_id=self._id_generator.new(CausationId),
             correlation_id=correlation_id,

--- a/src/bearagent/application/run_queries.py
+++ b/src/bearagent/application/run_queries.py
@@ -9,6 +9,7 @@ from bearagent.domain.ids import RunId
 from bearagent.domain.queries import EventPage, RunInspection
 from bearagent.domain.run_events import (
     RunCreatedPayloadV3,
+    RunCreatedPayloadV4,
     ToolCallCompletedPayloadV2,
     parse_run_event_payload,
 )
@@ -74,10 +75,14 @@ class RunQueryService:
 
         artifacts: list[Artifact] = []
         provider_selection = None
+        run_fingerprint = None
         try:
             for event in events:
                 payload = parse_run_event_payload(event)
-                if isinstance(payload, RunCreatedPayloadV3):
+                if isinstance(payload, RunCreatedPayloadV4):
+                    provider_selection = payload.provider_selection
+                    run_fingerprint = payload.run_fingerprint
+                elif isinstance(payload, RunCreatedPayloadV3):
                     provider_selection = payload.provider_selection
                 if not isinstance(payload, ToolCallCompletedPayloadV2):
                     continue
@@ -92,6 +97,7 @@ class RunQueryService:
                 state=state,
                 artifacts=tuple(artifacts),
                 provider_selection=provider_selection,
+                run_fingerprint=run_fingerprint,
             )
         except (KeyError, ValidationError, ValueError) as error:
             raise _invalid_history(cause=error) from error

--- a/src/bearagent/bootstrap.py
+++ b/src/bearagent/bootstrap.py
@@ -10,6 +10,7 @@ from typing import Annotated
 
 from pydantic import Field, TypeAdapter, ValidationError
 
+from bearagent import package_version
 from bearagent.adapters.model import (
     AnthropicMessagesProvider,
     OpenAIChatCompletionsProvider,
@@ -24,6 +25,7 @@ from bearagent.domain.errors import BearAgentError, ErrorCategory, ErrorCode, Er
 from bearagent.domain.ids import IdGenerator
 from bearagent.domain.providers import ModelProtocol, ProviderSelection
 from bearagent.ports.model import ModelProvider
+from bearagent.runtime.fingerprints import build_run_fingerprint
 from bearagent.runtime.policy import FixedToolPolicy
 from bearagent.runtime.tool_executor import ToolExecutor
 from bearagent.runtime.tool_registry import ToolRegistry
@@ -160,6 +162,11 @@ async def build_run_services(
             tool_executor=executor,
             id_generator=id_generator,
             provider_selection=provider_selection,
+            run_fingerprint=build_run_fingerprint(
+                bearagent_version=package_version(),
+                policy=policy.fingerprint,
+                tool_specs=registry.specs,
+            ),
         ),
         queries=RunQueryService(store),
     )

--- a/src/bearagent/domain/__init__.py
+++ b/src/bearagent/domain/__init__.py
@@ -19,6 +19,11 @@ from bearagent.domain.artifacts import (
 )
 from bearagent.domain.errors import BearAgentError, ErrorCategory, ErrorCode, ErrorInfo
 from bearagent.domain.events import Event
+from bearagent.domain.fingerprints import (
+    PolicyFingerprint,
+    RunFingerprint,
+    ToolFingerprint,
+)
 from bearagent.domain.ids import (
     ActivityId,
     ArtifactId,
@@ -66,6 +71,7 @@ from bearagent.domain.run_events import (
     RunCreatedPayload,
     RunCreatedPayloadV2,
     RunCreatedPayloadV3,
+    RunCreatedPayloadV4,
     RunFailedPayload,
     RunFailedPayloadV2,
     RunStartedPayload,
@@ -159,15 +165,18 @@ __all__ = [
     "ModelProtocol",
     "OpaqueId",
     "PolicyDecision",
+    "PolicyFingerprint",
     "PolicyOutcome",
     "PolicyReason",
     "PreparedToolRequest",
     "ProviderSelection",
     "RunId",
+    "RunFingerprint",
     "RunCreatedPayload",
     "RunCreatedPayloadV2",
     "RunFailedPayload",
     "RunCreatedPayloadV3",
+    "RunCreatedPayloadV4",
     "RunFailedPayloadV2",
     "RunInput",
     "RunInspection",
@@ -193,6 +202,7 @@ __all__ = [
     "ToolCallStartedPayloadV2",
     "ToolCallPart",
     "ToolExecutionRecord",
+    "ToolFingerprint",
     "ToolRequest",
     "ToolResult",
     "ToolResultPart",

--- a/src/bearagent/domain/errors.py
+++ b/src/bearagent/domain/errors.py
@@ -124,7 +124,13 @@ class ErrorInfo(DomainModel):
     category: ErrorCategory
     code: ErrorCode
     message: str = Field(min_length=1, max_length=MAX_ERROR_MESSAGE_CHARS)
-    retryable: bool = False
+    retryable: bool = Field(
+        default=False,
+        description=(
+            "Source-side observation that another attempt may succeed; never Runtime "
+            "permission to retry an Activity."
+        ),
+    )
     details: Mapping[str, SafeDetailValue] = Field(
         default_factory=dict,
         max_length=MAX_ERROR_DETAILS,

--- a/src/bearagent/domain/fingerprints.py
+++ b/src/bearagent/domain/fingerprints.py
@@ -1,0 +1,44 @@
+"""Finite identities for the trusted contracts used by one Run."""
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from bearagent.domain._base import DomainModel
+from bearagent.domain.messages import TOOL_NAME_PATTERN
+
+CONTRACT_VERSION_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$"
+BEARAGENT_VERSION_PATTERN = CONTRACT_VERSION_PATTERN
+SHA256_PATTERN = r"^[0-9a-f]{64}$"
+
+
+class PolicyFingerprint(DomainModel):
+    """Identity of one trusted static Policy evaluator and configuration."""
+
+    version: str = Field(pattern=CONTRACT_VERSION_PATTERN)
+    sha256: str = Field(pattern=SHA256_PATTERN)
+
+
+class ToolFingerprint(DomainModel):
+    """Identity of one registration-time Tool contract."""
+
+    name: str = Field(pattern=TOOL_NAME_PATTERN)
+    spec_version: str = Field(pattern=CONTRACT_VERSION_PATTERN)
+    sha256: str = Field(pattern=SHA256_PATTERN)
+
+
+class RunFingerprint(DomainModel):
+    """Trusted contract provenance captured once when a Run is created."""
+
+    bearagent_version: str = Field(pattern=BEARAGENT_VERSION_PATTERN)
+    policy: PolicyFingerprint
+    tools: tuple[ToolFingerprint, ...] = ()
+
+    @model_validator(mode="after")
+    def require_unique_sorted_tools(self) -> Self:
+        names = tuple(tool.name for tool in self.tools)
+        if len(names) != len(set(names)):
+            raise ValueError("Run fingerprint Tool names must be unique")
+        if names != tuple(sorted(names)):
+            raise ValueError("Run fingerprint Tools must be sorted by name")
+        return self

--- a/src/bearagent/domain/queries.py
+++ b/src/bearagent/domain/queries.py
@@ -7,6 +7,7 @@ from pydantic import Field, model_validator
 from bearagent.domain._base import DomainModel
 from bearagent.domain.artifacts import Artifact
 from bearagent.domain.events import Event
+from bearagent.domain.fingerprints import RunFingerprint
 from bearagent.domain.ids import RunId
 from bearagent.domain.providers import ProviderSelection
 from bearagent.domain.runs import RunState
@@ -22,6 +23,7 @@ class RunInspection(DomainModel):
     state: RunState
     artifacts: tuple[Artifact, ...] = ()
     provider_selection: ProviderSelection | None = None
+    run_fingerprint: RunFingerprint | None = None
 
     @model_validator(mode="after")
     def require_one_consistent_run(self) -> Self:

--- a/src/bearagent/domain/run_events.py
+++ b/src/bearagent/domain/run_events.py
@@ -9,6 +9,7 @@ from bearagent.domain._base import DomainModel, thaw_json_mapping
 from bearagent.domain.agent import AgentConfig, ContextBuildReport
 from bearagent.domain.errors import ErrorInfo
 from bearagent.domain.events import Event
+from bearagent.domain.fingerprints import RunFingerprint
 from bearagent.domain.ids import ActivityId, ModelCallId, SessionId, ToolCallId
 from bearagent.domain.messages import TOOL_NAME_PATTERN, Message, MessageRole, ToolCallPart
 from bearagent.domain.model import (
@@ -24,7 +25,8 @@ from bearagent.domain.tools import ToolExecutionRecord, ToolRequest, ToolStatus
 RUN_EVENT_SCHEMA_VERSION = 1
 RUN_EVENT_SCHEMA_VERSION_V2 = 2
 RUN_EVENT_SCHEMA_VERSION_V3 = 3
-LATEST_RUN_EVENT_SCHEMA_VERSION = RUN_EVENT_SCHEMA_VERSION_V3
+RUN_EVENT_SCHEMA_VERSION_V4 = 4
+LATEST_RUN_EVENT_SCHEMA_VERSION = RUN_EVENT_SCHEMA_VERSION_V4
 
 
 class RunCreatedPayload(DomainModel):
@@ -124,6 +126,13 @@ class RunCreatedPayloadV3(RunCreatedPayloadV2):
     """v3 Run creation fact with a non-secret Provider selection."""
 
     provider_selection: ProviderSelection
+
+
+class RunCreatedPayloadV4(RunCreatedPayloadV2):
+    """v4 Run creation fact with trusted contract provenance."""
+
+    run_fingerprint: RunFingerprint
+    provider_selection: ProviderSelection | None = None
 
 
 class RunStartedPayloadV2(RunStartedPayload):
@@ -238,6 +247,7 @@ type RunEventPayload = (
     | ToolCallFailedPayload
     | RunCreatedPayloadV2
     | RunCreatedPayloadV3
+    | RunCreatedPayloadV4
     | RunStartedPayloadV2
     | RunSucceededPayloadV2
     | RunFailedPayloadV2
@@ -289,6 +299,18 @@ _PAYLOAD_TYPES = {
     ("ToolCallStarted", RUN_EVENT_SCHEMA_VERSION_V3): ToolCallStartedPayloadV2,
     ("ToolCallCompleted", RUN_EVENT_SCHEMA_VERSION_V3): ToolCallCompletedPayloadV2,
     ("ToolCallFailed", RUN_EVENT_SCHEMA_VERSION_V3): ToolCallFailedPayloadV2,
+    ("RunCreated", RUN_EVENT_SCHEMA_VERSION_V4): RunCreatedPayloadV4,
+    ("RunStarted", RUN_EVENT_SCHEMA_VERSION_V4): RunStartedPayloadV2,
+    ("RunSucceeded", RUN_EVENT_SCHEMA_VERSION_V4): RunSucceededPayloadV2,
+    ("RunFailed", RUN_EVENT_SCHEMA_VERSION_V4): RunFailedPayloadV2,
+    ("ModelCallRequested", RUN_EVENT_SCHEMA_VERSION_V4): ModelCallRequestedPayloadV2,
+    ("ModelCallStarted", RUN_EVENT_SCHEMA_VERSION_V4): ModelCallStartedPayloadV2,
+    ("ModelCallCompleted", RUN_EVENT_SCHEMA_VERSION_V4): ModelCallCompletedPayloadV2,
+    ("ModelCallFailed", RUN_EVENT_SCHEMA_VERSION_V4): ModelCallFailedPayloadV2,
+    ("ToolCallRequested", RUN_EVENT_SCHEMA_VERSION_V4): ToolCallRequestedPayloadV2,
+    ("ToolCallStarted", RUN_EVENT_SCHEMA_VERSION_V4): ToolCallStartedPayloadV2,
+    ("ToolCallCompleted", RUN_EVENT_SCHEMA_VERSION_V4): ToolCallCompletedPayloadV2,
+    ("ToolCallFailed", RUN_EVENT_SCHEMA_VERSION_V4): ToolCallFailedPayloadV2,
 }
 
 RUN_EVENT_PAYLOAD_TYPES = MappingProxyType(_PAYLOAD_TYPES)

--- a/src/bearagent/domain/schema.py
+++ b/src/bearagent/domain/schema.py
@@ -16,6 +16,11 @@ from bearagent.domain.agent import (
 from bearagent.domain.artifacts import Artifact
 from bearagent.domain.errors import ErrorInfo
 from bearagent.domain.events import Event
+from bearagent.domain.fingerprints import (
+    PolicyFingerprint,
+    RunFingerprint,
+    ToolFingerprint,
+)
 from bearagent.domain.ids import (
     ActivityId,
     ArtifactId,
@@ -50,6 +55,7 @@ from bearagent.domain.run_events import (
     RunCreatedPayload,
     RunCreatedPayloadV2,
     RunCreatedPayloadV3,
+    RunCreatedPayloadV4,
     RunFailedPayload,
     RunFailedPayloadV2,
     RunStartedPayload,
@@ -118,8 +124,11 @@ PUBLIC_SCHEMA_MODELS: tuple[type[BaseModel], ...] = (
     ModelUsage,
     ModelPricing,
     PolicyDecision,
+    PolicyFingerprint,
     PreparedToolRequest,
     RunCreatedPayloadV3,
+    RunCreatedPayloadV4,
+    RunFingerprint,
     RunId,
     RunCreatedPayload,
     RunCreatedPayloadV2,
@@ -146,6 +155,7 @@ PUBLIC_SCHEMA_MODELS: tuple[type[BaseModel], ...] = (
     ToolCallStartedPayload,
     ToolCallStartedPayloadV2,
     ToolExecutionRecord,
+    ToolFingerprint,
     ToolRequest,
     ToolResult,
     ToolSpec,

--- a/src/bearagent/domain/tools.py
+++ b/src/bearagent/domain/tools.py
@@ -15,6 +15,7 @@ from bearagent.domain._base import (
     validate_json_object,
 )
 from bearagent.domain.errors import ErrorCode, ErrorInfo
+from bearagent.domain.fingerprints import CONTRACT_VERSION_PATTERN
 from bearagent.domain.ids import ToolCallId
 from bearagent.domain.messages import TOOL_NAME_PATTERN
 
@@ -43,7 +44,7 @@ class ToolSideEffect(StrEnum):
 
 
 class ToolRetrySafety(StrEnum):
-    """Whether a later runtime may safely retry a Tool call."""
+    """Coarse Tool contract hint; never permission to retry an Activity by itself."""
 
     NOT_SAFE = "not_safe"
     SAFE = "safe"
@@ -83,6 +84,7 @@ class ToolSpec(DomainModel):
     """Trusted registration data and resource limits for one Tool."""
 
     name: str = Field(pattern=TOOL_NAME_PATTERN)
+    spec_version: str = Field(pattern=CONTRACT_VERSION_PATTERN)
     description: str = Field(min_length=1, max_length=MAX_TOOL_DESCRIPTION_CHARS)
     input_schema: Mapping[str, JsonValue]
     output_schema: Mapping[str, JsonValue]

--- a/src/bearagent/interfaces/cli/main.py
+++ b/src/bearagent/interfaces/cli/main.py
@@ -171,8 +171,6 @@ def run_objective(
                 database=database,
             )
         )
-    except (BearAgentError, ValidationError, ValueError, OSError) as error:
-        _exit_with_error("run", error, json_output=json_output)
     except Exception as error:
         _exit_with_error("run", error, json_output=json_output)
 
@@ -196,8 +194,6 @@ def inspect_run(
     """Show the reducer projection and committed Artifact metadata."""
     try:
         output = asyncio.run(_inspect_existing_run(run_id=run_id, database=database))
-    except (BearAgentError, ValidationError, ValueError, OSError) as error:
-        _exit_with_error("inspect", error, json_output=json_output)
     except Exception as error:
         _exit_with_error("inspect", error, json_output=json_output)
     typer.echo(render_json(output) if json_output else render_inspection(output.result))
@@ -233,8 +229,6 @@ def list_run_events(
                 limit=limit,
             )
         )
-    except (BearAgentError, ValidationError, ValueError, OSError) as error:
-        _exit_with_error("events", error, json_output=json_output)
     except Exception as error:
         _exit_with_error("events", error, json_output=json_output)
     typer.echo(render_json(output) if json_output else render_events(output.result))

--- a/src/bearagent/interfaces/cli/renderers.py
+++ b/src/bearagent/interfaces/cli/renderers.py
@@ -72,6 +72,21 @@ def render_inspection(inspection: RunInspection) -> str:
                 f"Provider config version: {selection.config_version}",
             )
         )
+    if inspection.run_fingerprint is not None:
+        fingerprint = inspection.run_fingerprint
+        lines.extend(
+            (
+                f"BearAgent version: {fingerprint.bearagent_version}",
+                (
+                    f"Policy contract: {fingerprint.policy.version} "
+                    f"sha256={fingerprint.policy.sha256}"
+                ),
+            )
+        )
+        lines.extend(
+            f"Tool contract: {tool.name} {tool.spec_version} sha256={tool.sha256}"
+            for tool in fingerprint.tools
+        )
     for activity in state.activities:
         label = activity.kind.value
         if activity.tool_name is not None:

--- a/src/bearagent/runtime/__init__.py
+++ b/src/bearagent/runtime/__init__.py
@@ -2,6 +2,7 @@
 
 from bearagent.runtime.budgets import check_activity_budget
 from bearagent.runtime.context import ContextBuilder, ContextBuilderError
+from bearagent.runtime.fingerprints import build_run_fingerprint
 from bearagent.runtime.policy import FixedToolPolicy
 from bearagent.runtime.pricing import estimate_model_cost_microusd
 from bearagent.runtime.reducer import RunReducerError, reduce_event, reduce_events
@@ -16,6 +17,7 @@ __all__ = [
     "ToolExecutor",
     "ToolRegistry",
     "check_activity_budget",
+    "build_run_fingerprint",
     "estimate_model_cost_microusd",
     "reduce_event",
     "reduce_events",

--- a/src/bearagent/runtime/fingerprints.py
+++ b/src/bearagent/runtime/fingerprints.py
@@ -1,0 +1,59 @@
+"""Deterministic hashing for trusted Run contract declarations."""
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from typing import cast
+
+from pydantic import JsonValue
+
+from bearagent.domain.fingerprints import PolicyFingerprint, RunFingerprint, ToolFingerprint
+from bearagent.domain.tools import ToolSpec
+
+
+def policy_fingerprint(
+    *,
+    version: str,
+    contract: Mapping[str, JsonValue],
+) -> PolicyFingerprint:
+    """Identify a bounded static Policy contract without persisting the contract body."""
+    return PolicyFingerprint(version=version, sha256=canonical_sha256(contract))
+
+
+def tool_fingerprint(spec: ToolSpec) -> ToolFingerprint:
+    """Identify the exact declared registration-time ToolSpec."""
+    contract = cast(dict[str, JsonValue], spec.model_dump(mode="json"))
+    return ToolFingerprint(
+        name=spec.name,
+        spec_version=spec.spec_version,
+        sha256=canonical_sha256(contract),
+    )
+
+
+def build_run_fingerprint(
+    *,
+    bearagent_version: str,
+    policy: PolicyFingerprint,
+    tool_specs: Iterable[ToolSpec],
+) -> RunFingerprint:
+    """Build one stable Run identity from trusted composition inputs."""
+    tools = tuple(
+        sorted((tool_fingerprint(spec) for spec in tool_specs), key=lambda item: item.name)
+    )
+    return RunFingerprint(
+        bearagent_version=bearagent_version,
+        policy=policy,
+        tools=tools,
+    )
+
+
+def canonical_sha256(value: Mapping[str, JsonValue]) -> str:
+    """Hash canonical UTF-8 JSON rather than Python object representations."""
+    serialized = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(serialized).hexdigest()

--- a/src/bearagent/runtime/policy.py
+++ b/src/bearagent/runtime/policy.py
@@ -2,7 +2,11 @@
 
 import re
 from collections.abc import Iterable
+from typing import cast
 
+from pydantic import JsonValue
+
+from bearagent.domain.fingerprints import PolicyFingerprint
 from bearagent.domain.messages import TOOL_NAME_PATTERN
 from bearagent.domain.tools import (
     PolicyDecision,
@@ -12,6 +16,7 @@ from bearagent.domain.tools import (
     ToolSideEffect,
     ToolSpec,
 )
+from bearagent.runtime.fingerprints import policy_fingerprint
 
 _DENIED_SIDE_EFFECTS = frozenset(
     {
@@ -19,6 +24,7 @@ _DENIED_SIDE_EFFECTS = frozenset(
         ToolSideEffect.CODE_EXECUTION,
     }
 )
+_FIXED_POLICY_VERSION = "fixed-tool-policy-v1"
 
 
 class FixedToolPolicy:
@@ -34,11 +40,29 @@ class FixedToolPolicy:
                 raise ValueError("allowed Tool name is invalid")
             validated_names.append(name)
         self._allowed_tool_names = frozenset(validated_names)
+        contract: dict[str, JsonValue] = {
+            "policy_type": "fixed_tool_policy",
+            "version": _FIXED_POLICY_VERSION,
+            "allowed_tool_names": cast(JsonValue, sorted(self._allowed_tool_names)),
+            "hard_denied_side_effects": cast(
+                JsonValue,
+                sorted(effect.value for effect in _DENIED_SIDE_EFFECTS),
+            ),
+        }
+        self._fingerprint = policy_fingerprint(
+            version=_FIXED_POLICY_VERSION,
+            contract=contract,
+        )
 
     @property
     def allowed_tool_names(self) -> frozenset[str]:
         """Return the immutable trusted allowlist snapshot."""
         return self._allowed_tool_names
+
+    @property
+    def fingerprint(self) -> PolicyFingerprint:
+        """Return the snapshotted identity of this trusted static Policy contract."""
+        return self._fingerprint
 
     def evaluate(self, spec: ToolSpec, request: PreparedToolRequest) -> PolicyDecision:
         """Evaluate trusted Tool metadata and normalized arguments."""

--- a/src/bearagent/runtime/reducer.py
+++ b/src/bearagent/runtime/reducer.py
@@ -63,8 +63,17 @@ def validate_event_history(prior_events: Iterable[Event], event: Event) -> None:
     """Validate facts that require earlier Event payloads, not projection fields."""
     if event.event_type not in {"ToolCallCompleted", "ToolCallFailed"}:
         return
-    if event.schema_version not in {2, 3}:
+
+    try:
+        terminal = parse_run_event_payload(event)
+    except (KeyError, ValidationError):
+        # reduce_event owns the stable error for an unsupported version or an
+        # invalid payload. History validation only applies when this schema
+        # carries the full execution evidence introduced in v2.
         return
+    if not isinstance(terminal, ToolCallCompletedPayloadV2 | ToolCallFailedPayloadV2):
+        return
+
     history = tuple(prior_events)
     if len(history) < 2:
         _fail_event(event, "versioned Tool terminal Event requires requested Event history.")
@@ -76,15 +85,11 @@ def validate_event_history(prior_events: Iterable[Event], event: Event) -> None:
         _fail_event(event, "versioned Tool terminal Event has invalid requested Event.")
     try:
         requested = parse_run_event_payload(requested_event)
-        terminal = parse_run_event_payload(event)
     except (KeyError, ValidationError) as cause:
         _fail_event(event, "versioned Tool Event history is invalid.", cause=cause)
     if not isinstance(requested, ToolCallRequestedPayloadV2):
         _fail_event(event, "versioned Tool requested Event payload is invalid.")
-    if (
-        isinstance(terminal, ToolCallCompletedPayloadV2 | ToolCallFailedPayloadV2)
-        and terminal.execution.request != requested.request
-    ):
+    if terminal.execution.request != requested.request:
         _fail_event(event, "Tool execution request does not match the requested Activity.")
 
 

--- a/src/bearagent/runtime/tool_registry.py
+++ b/src/bearagent/runtime/tool_registry.py
@@ -14,11 +14,12 @@ class ToolRegistry:
         by_name: dict[str, Tool] = {}
         specs_by_name: dict[str, ToolSpec] = {}
         for tool in tools:
-            name = tool.spec.name
+            spec = tool.spec
+            name = spec.name
             if name in by_name:
                 raise ValueError(f"duplicate Tool name: {name}")
             by_name[name] = tool
-            specs_by_name[name] = tool.spec
+            specs_by_name[name] = spec
         self._tools: Mapping[str, Tool] = MappingProxyType(by_name)
         self._specs_by_name: Mapping[str, ToolSpec] = MappingProxyType(specs_by_name)
         self._specs = tuple(specs_by_name[name] for name in sorted(specs_by_name))

--- a/tests/agent_loop_fixtures.py
+++ b/tests/agent_loop_fixtures.py
@@ -2,10 +2,12 @@ from datetime import UTC, datetime, timedelta
 
 from bearagent.adapters.testing import FakeTool
 from bearagent.domain.agent import AgentConfig, AgentSettings, ModelPricing, RunInput
+from bearagent.domain.fingerprints import RunFingerprint
 from bearagent.domain.ids import SessionId
 from bearagent.domain.model import ModelCompleted, ModelFinishReason, ModelUsage
 from bearagent.domain.runs import BudgetLimits
 from bearagent.domain.tools import ToolRetrySafety, ToolSideEffect, ToolSpec
+from bearagent.runtime.fingerprints import build_run_fingerprint
 from bearagent.runtime.policy import FixedToolPolicy
 from bearagent.runtime.tool_executor import ToolExecutor
 from bearagent.runtime.tool_registry import ToolRegistry
@@ -26,6 +28,7 @@ class TickingClock:
 def read_tool_spec() -> ToolSpec:
     return ToolSpec(
         name="workspace.read",
+        spec_version="1",
         description="Read one workspace text file.",
         input_schema={
             "type": "object",
@@ -94,6 +97,20 @@ def tool_executor(tool: FakeTool | None = None) -> ToolExecutor:
         else tool
     )
     return ToolExecutor(ToolRegistry([registered]), FixedToolPolicy(["workspace.read"]))
+
+
+def run_fingerprint(
+    specs: tuple[ToolSpec, ...] | None = None,
+    *,
+    allowed_tool_names: tuple[str, ...] = ("workspace.read",),
+) -> RunFingerprint:
+    """Build a deterministic trusted composition identity for AgentLoop tests."""
+    policy = FixedToolPolicy(allowed_tool_names)
+    return build_run_fingerprint(
+        bearagent_version="0.1.0+test",
+        policy=policy.fingerprint,
+        tool_specs=(read_tool_spec(),) if specs is None else specs,
+    )
 
 
 def model_completed(

--- a/tests/contract/snapshots/cli_schemas.json
+++ b/tests/contract/snapshots/cli_schemas.json
@@ -68,6 +68,7 @@
           },
           "retryable": {
             "default": false,
+            "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
             "title": "Retryable",
             "type": "boolean"
           },
@@ -641,6 +642,7 @@
           },
           "retryable": {
             "default": false,
+            "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
             "title": "Retryable",
             "type": "boolean"
           },
@@ -677,6 +679,28 @@
         "title": "ModelProtocol",
         "type": "string"
       },
+      "PolicyFingerprint": {
+        "additionalProperties": false,
+        "description": "Identity of one trusted static Policy evaluator and configuration.",
+        "properties": {
+          "version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$",
+            "title": "Version",
+            "type": "string"
+          },
+          "sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Sha256",
+            "type": "string"
+          }
+        },
+        "required": [
+          "version",
+          "sha256"
+        ],
+        "title": "PolicyFingerprint",
+        "type": "object"
+      },
       "ProviderSelection": {
         "additionalProperties": false,
         "description": "Non-secret Provider identity persisted with a Run.",
@@ -701,6 +725,34 @@
           "protocol"
         ],
         "title": "ProviderSelection",
+        "type": "object"
+      },
+      "RunFingerprint": {
+        "additionalProperties": false,
+        "description": "Trusted contract provenance captured once when a Run is created.",
+        "properties": {
+          "bearagent_version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$",
+            "title": "Bearagent Version",
+            "type": "string"
+          },
+          "policy": {
+            "$ref": "#/$defs/PolicyFingerprint"
+          },
+          "tools": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ToolFingerprint"
+            },
+            "title": "Tools",
+            "type": "array"
+          }
+        },
+        "required": [
+          "bearagent_version",
+          "policy"
+        ],
+        "title": "RunFingerprint",
         "type": "object"
       },
       "RunId": {
@@ -731,6 +783,17 @@
             "anyOf": [
               {
                 "$ref": "#/$defs/ProviderSelection"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "run_fingerprint": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/RunFingerprint"
               },
               {
                 "type": "null"
@@ -873,6 +936,34 @@
         "format": "uuid4",
         "title": "ToolCallId",
         "type": "string"
+      },
+      "ToolFingerprint": {
+        "additionalProperties": false,
+        "description": "Identity of one registration-time Tool contract.",
+        "properties": {
+          "name": {
+            "pattern": "^[A-Za-z][A-Za-z0-9_.-]{0,127}$",
+            "title": "Name",
+            "type": "string"
+          },
+          "spec_version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$",
+            "title": "Spec Version",
+            "type": "string"
+          },
+          "sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Sha256",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "spec_version",
+          "sha256"
+        ],
+        "title": "ToolFingerprint",
+        "type": "object"
       }
     },
     "additionalProperties": false,
@@ -1246,6 +1337,7 @@
           },
           "retryable": {
             "default": false,
+            "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
             "title": "Retryable",
             "type": "boolean"
           },

--- a/tests/contract/snapshots/domain_schemas.json
+++ b/tests/contract/snapshots/domain_schemas.json
@@ -100,6 +100,7 @@
           },
           "retryable": {
             "default": false,
+            "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
             "title": "Retryable",
             "type": "boolean"
           },
@@ -1111,6 +1112,7 @@
       },
       "retryable": {
         "default": false,
+        "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
         "title": "Retryable",
         "type": "boolean"
       },
@@ -1882,6 +1884,7 @@
           },
           "retryable": {
             "default": false,
+            "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
             "title": "Retryable",
             "type": "boolean"
           },
@@ -2042,6 +2045,7 @@
           },
           "retryable": {
             "default": false,
+            "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
             "title": "Retryable",
             "type": "boolean"
           },
@@ -3091,6 +3095,28 @@
     "title": "PolicyDecision",
     "type": "object"
   },
+  "PolicyFingerprint": {
+    "additionalProperties": false,
+    "description": "Identity of one trusted static Policy evaluator and configuration.",
+    "properties": {
+      "version": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$",
+        "title": "Version",
+        "type": "string"
+      },
+      "sha256": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Sha256",
+        "type": "string"
+      }
+    },
+    "required": [
+      "version",
+      "sha256"
+    ],
+    "title": "PolicyFingerprint",
+    "type": "object"
+  },
   "PreparedToolRequest": {
     "$defs": {
       "JsonValue": {},
@@ -3676,6 +3702,335 @@
     "title": "RunCreatedPayloadV3",
     "type": "object"
   },
+  "RunCreatedPayloadV4": {
+    "$defs": {
+      "AgentConfig": {
+        "additionalProperties": false,
+        "description": "Resolved non-secret Agent snapshot persisted for one Run.",
+        "properties": {
+          "agent_id": {
+            "pattern": "^[A-Za-z][A-Za-z0-9._-]{0,127}$",
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "agent_version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$",
+            "title": "Agent Version",
+            "type": "string"
+          },
+          "instructions": {
+            "maxLength": 65536,
+            "minLength": 1,
+            "title": "Instructions",
+            "type": "string"
+          },
+          "prompt_version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$",
+            "title": "Prompt Version",
+            "type": "string"
+          },
+          "context_version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$",
+            "title": "Context Version",
+            "type": "string"
+          },
+          "max_output_tokens": {
+            "exclusiveMinimum": 0,
+            "maximum": 10000000000,
+            "title": "Max Output Tokens",
+            "type": "integer"
+          },
+          "model_timeout_ms": {
+            "exclusiveMinimum": 0,
+            "maximum": 600000,
+            "title": "Model Timeout Ms",
+            "type": "integer"
+          },
+          "max_context_chars": {
+            "exclusiveMinimum": 0,
+            "maximum": 4000000,
+            "title": "Max Context Chars",
+            "type": "integer"
+          },
+          "max_tool_result_bytes": {
+            "maximum": 4000000,
+            "minimum": 128,
+            "title": "Max Tool Result Bytes",
+            "type": "integer"
+          },
+          "tool_names": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 128,
+            "title": "Tool Names",
+            "type": "array"
+          },
+          "model": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$",
+            "title": "Model",
+            "type": "string"
+          },
+          "pricing": {
+            "$ref": "#/$defs/ModelPricing"
+          }
+        },
+        "required": [
+          "agent_id",
+          "agent_version",
+          "instructions",
+          "prompt_version",
+          "context_version",
+          "max_output_tokens",
+          "model_timeout_ms",
+          "max_context_chars",
+          "max_tool_result_bytes",
+          "model",
+          "pricing"
+        ],
+        "title": "AgentConfig",
+        "type": "object"
+      },
+      "BudgetLimits": {
+        "additionalProperties": false,
+        "description": "Finite limits selected by a trusted Run creation boundary.",
+        "properties": {
+          "max_model_iterations": {
+            "maximum": 100000,
+            "minimum": 0,
+            "title": "Max Model Iterations",
+            "type": "integer"
+          },
+          "max_tokens": {
+            "maximum": 10000000000,
+            "minimum": 0,
+            "title": "Max Tokens",
+            "type": "integer"
+          },
+          "max_cost_microusd": {
+            "maximum": 1000000000000,
+            "minimum": 0,
+            "title": "Max Cost Microusd",
+            "type": "integer"
+          },
+          "max_wall_time_ms": {
+            "maximum": 2678400000,
+            "minimum": 0,
+            "title": "Max Wall Time Ms",
+            "type": "integer"
+          },
+          "max_tool_calls": {
+            "maximum": 1000000,
+            "minimum": 0,
+            "title": "Max Tool Calls",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "max_model_iterations",
+          "max_tokens",
+          "max_cost_microusd",
+          "max_wall_time_ms",
+          "max_tool_calls"
+        ],
+        "title": "BudgetLimits",
+        "type": "object"
+      },
+      "ModelPricing": {
+        "additionalProperties": false,
+        "description": "Versioned integer rates used for deterministic local cost estimates.",
+        "properties": {
+          "version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$",
+            "title": "Version",
+            "type": "string"
+          },
+          "input_microusd_per_million_tokens": {
+            "maximum": 1000000000000,
+            "minimum": 0,
+            "title": "Input Microusd Per Million Tokens",
+            "type": "integer"
+          },
+          "output_microusd_per_million_tokens": {
+            "maximum": 1000000000000,
+            "minimum": 0,
+            "title": "Output Microusd Per Million Tokens",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "version",
+          "input_microusd_per_million_tokens",
+          "output_microusd_per_million_tokens"
+        ],
+        "title": "ModelPricing",
+        "type": "object"
+      },
+      "ModelProtocol": {
+        "description": "An explicitly selected wire protocol implemented by a model adapter.",
+        "enum": [
+          "openai_responses",
+          "openai_chat_completions",
+          "anthropic_messages"
+        ],
+        "title": "ModelProtocol",
+        "type": "string"
+      },
+      "PolicyFingerprint": {
+        "additionalProperties": false,
+        "description": "Identity of one trusted static Policy evaluator and configuration.",
+        "properties": {
+          "version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$",
+            "title": "Version",
+            "type": "string"
+          },
+          "sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Sha256",
+            "type": "string"
+          }
+        },
+        "required": [
+          "version",
+          "sha256"
+        ],
+        "title": "PolicyFingerprint",
+        "type": "object"
+      },
+      "ProviderSelection": {
+        "additionalProperties": false,
+        "description": "Non-secret Provider identity persisted with a Run.",
+        "properties": {
+          "provider_id": {
+            "pattern": "^[A-Za-z][A-Za-z0-9._-]{0,63}$",
+            "title": "Provider Id",
+            "type": "string"
+          },
+          "config_version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$",
+            "title": "Config Version",
+            "type": "string"
+          },
+          "protocol": {
+            "$ref": "#/$defs/ModelProtocol"
+          }
+        },
+        "required": [
+          "provider_id",
+          "config_version",
+          "protocol"
+        ],
+        "title": "ProviderSelection",
+        "type": "object"
+      },
+      "RunFingerprint": {
+        "additionalProperties": false,
+        "description": "Trusted contract provenance captured once when a Run is created.",
+        "properties": {
+          "bearagent_version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$",
+            "title": "Bearagent Version",
+            "type": "string"
+          },
+          "policy": {
+            "$ref": "#/$defs/PolicyFingerprint"
+          },
+          "tools": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ToolFingerprint"
+            },
+            "title": "Tools",
+            "type": "array"
+          }
+        },
+        "required": [
+          "bearagent_version",
+          "policy"
+        ],
+        "title": "RunFingerprint",
+        "type": "object"
+      },
+      "SessionId": {
+        "description": "Identify a conversation container.",
+        "format": "uuid4",
+        "title": "SessionId",
+        "type": "string"
+      },
+      "ToolFingerprint": {
+        "additionalProperties": false,
+        "description": "Identity of one registration-time Tool contract.",
+        "properties": {
+          "name": {
+            "pattern": "^[A-Za-z][A-Za-z0-9_.-]{0,127}$",
+            "title": "Name",
+            "type": "string"
+          },
+          "spec_version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$",
+            "title": "Spec Version",
+            "type": "string"
+          },
+          "sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Sha256",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "spec_version",
+          "sha256"
+        ],
+        "title": "ToolFingerprint",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "v4 Run creation fact with trusted contract provenance.",
+    "properties": {
+      "session_id": {
+        "$ref": "#/$defs/SessionId"
+      },
+      "budget_limits": {
+        "$ref": "#/$defs/BudgetLimits"
+      },
+      "objective": {
+        "maxLength": 1000000,
+        "minLength": 1,
+        "title": "Objective",
+        "type": "string"
+      },
+      "agent_config": {
+        "$ref": "#/$defs/AgentConfig"
+      },
+      "run_fingerprint": {
+        "$ref": "#/$defs/RunFingerprint"
+      },
+      "provider_selection": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/ProviderSelection"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      }
+    },
+    "required": [
+      "session_id",
+      "budget_limits",
+      "objective",
+      "agent_config",
+      "run_fingerprint"
+    ],
+    "title": "RunCreatedPayloadV4",
+    "type": "object"
+  },
   "RunFailedPayload": {
     "$defs": {
       "ErrorCategory": {
@@ -3745,6 +4100,7 @@
           },
           "retryable": {
             "default": false,
+            "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
             "title": "Retryable",
             "type": "boolean"
           },
@@ -3867,6 +4223,7 @@
           },
           "retryable": {
             "default": false,
+            "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
             "title": "Retryable",
             "type": "boolean"
           },
@@ -3918,6 +4275,86 @@
       "error"
     ],
     "title": "RunFailedPayloadV2",
+    "type": "object"
+  },
+  "RunFingerprint": {
+    "$defs": {
+      "PolicyFingerprint": {
+        "additionalProperties": false,
+        "description": "Identity of one trusted static Policy evaluator and configuration.",
+        "properties": {
+          "version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$",
+            "title": "Version",
+            "type": "string"
+          },
+          "sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Sha256",
+            "type": "string"
+          }
+        },
+        "required": [
+          "version",
+          "sha256"
+        ],
+        "title": "PolicyFingerprint",
+        "type": "object"
+      },
+      "ToolFingerprint": {
+        "additionalProperties": false,
+        "description": "Identity of one registration-time Tool contract.",
+        "properties": {
+          "name": {
+            "pattern": "^[A-Za-z][A-Za-z0-9_.-]{0,127}$",
+            "title": "Name",
+            "type": "string"
+          },
+          "spec_version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$",
+            "title": "Spec Version",
+            "type": "string"
+          },
+          "sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Sha256",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "spec_version",
+          "sha256"
+        ],
+        "title": "ToolFingerprint",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Trusted contract provenance captured once when a Run is created.",
+    "properties": {
+      "bearagent_version": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$",
+        "title": "Bearagent Version",
+        "type": "string"
+      },
+      "policy": {
+        "$ref": "#/$defs/PolicyFingerprint"
+      },
+      "tools": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/ToolFingerprint"
+        },
+        "title": "Tools",
+        "type": "array"
+      }
+    },
+    "required": [
+      "bearagent_version",
+      "policy"
+    ],
+    "title": "RunFingerprint",
     "type": "object"
   },
   "RunId": {
@@ -4472,6 +4909,7 @@
           },
           "retryable": {
             "default": false,
+            "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
             "title": "Retryable",
             "type": "boolean"
           },
@@ -4508,6 +4946,28 @@
         "title": "ModelProtocol",
         "type": "string"
       },
+      "PolicyFingerprint": {
+        "additionalProperties": false,
+        "description": "Identity of one trusted static Policy evaluator and configuration.",
+        "properties": {
+          "version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$",
+            "title": "Version",
+            "type": "string"
+          },
+          "sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Sha256",
+            "type": "string"
+          }
+        },
+        "required": [
+          "version",
+          "sha256"
+        ],
+        "title": "PolicyFingerprint",
+        "type": "object"
+      },
       "ProviderSelection": {
         "additionalProperties": false,
         "description": "Non-secret Provider identity persisted with a Run.",
@@ -4532,6 +4992,34 @@
           "protocol"
         ],
         "title": "ProviderSelection",
+        "type": "object"
+      },
+      "RunFingerprint": {
+        "additionalProperties": false,
+        "description": "Trusted contract provenance captured once when a Run is created.",
+        "properties": {
+          "bearagent_version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$",
+            "title": "Bearagent Version",
+            "type": "string"
+          },
+          "policy": {
+            "$ref": "#/$defs/PolicyFingerprint"
+          },
+          "tools": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ToolFingerprint"
+            },
+            "title": "Tools",
+            "type": "array"
+          }
+        },
+        "required": [
+          "bearagent_version",
+          "policy"
+        ],
+        "title": "RunFingerprint",
         "type": "object"
       },
       "RunId": {
@@ -4667,6 +5155,34 @@
         "format": "uuid4",
         "title": "ToolCallId",
         "type": "string"
+      },
+      "ToolFingerprint": {
+        "additionalProperties": false,
+        "description": "Identity of one registration-time Tool contract.",
+        "properties": {
+          "name": {
+            "pattern": "^[A-Za-z][A-Za-z0-9_.-]{0,127}$",
+            "title": "Name",
+            "type": "string"
+          },
+          "spec_version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$",
+            "title": "Spec Version",
+            "type": "string"
+          },
+          "sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Sha256",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "spec_version",
+          "sha256"
+        ],
+        "title": "ToolFingerprint",
+        "type": "object"
       }
     },
     "additionalProperties": false,
@@ -4690,6 +5206,17 @@
         "anyOf": [
           {
             "$ref": "#/$defs/ProviderSelection"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      },
+      "run_fingerprint": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/RunFingerprint"
           },
           {
             "type": "null"
@@ -5395,6 +5922,7 @@
           },
           "retryable": {
             "default": false,
+            "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
             "title": "Retryable",
             "type": "boolean"
           },
@@ -5892,6 +6420,7 @@
           },
           "retryable": {
             "default": false,
+            "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
             "title": "Retryable",
             "type": "boolean"
           },
@@ -6179,6 +6708,7 @@
           },
           "retryable": {
             "default": false,
+            "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
             "title": "Retryable",
             "type": "boolean"
           },
@@ -6508,6 +7038,7 @@
           },
           "retryable": {
             "default": false,
+            "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
             "title": "Retryable",
             "type": "boolean"
           },
@@ -6650,6 +7181,7 @@
           },
           "retryable": {
             "default": false,
+            "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
             "title": "Retryable",
             "type": "boolean"
           },
@@ -7155,6 +7687,7 @@
           },
           "retryable": {
             "default": false,
+            "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
             "title": "Retryable",
             "type": "boolean"
           },
@@ -7387,6 +7920,34 @@
     "title": "ToolExecutionRecord",
     "type": "object"
   },
+  "ToolFingerprint": {
+    "additionalProperties": false,
+    "description": "Identity of one registration-time Tool contract.",
+    "properties": {
+      "name": {
+        "pattern": "^[A-Za-z][A-Za-z0-9_.-]{0,127}$",
+        "title": "Name",
+        "type": "string"
+      },
+      "spec_version": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$",
+        "title": "Spec Version",
+        "type": "string"
+      },
+      "sha256": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Sha256",
+        "type": "string"
+      }
+    },
+    "required": [
+      "name",
+      "spec_version",
+      "sha256"
+    ],
+    "title": "ToolFingerprint",
+    "type": "object"
+  },
   "ToolRequest": {
     "$defs": {
       "JsonValue": {},
@@ -7492,6 +8053,7 @@
           },
           "retryable": {
             "default": false,
+            "description": "Source-side observation that another attempt may succeed; never Runtime permission to retry an Activity.",
             "title": "Retryable",
             "type": "boolean"
           },
@@ -7587,7 +8149,7 @@
     "$defs": {
       "JsonValue": {},
       "ToolRetrySafety": {
-        "description": "Whether a later runtime may safely retry a Tool call.",
+        "description": "Coarse Tool contract hint; never permission to retry an Activity by itself.",
         "enum": [
           "not_safe",
           "safe"
@@ -7613,6 +8175,11 @@
       "name": {
         "pattern": "^[A-Za-z][A-Za-z0-9_.-]{0,127}$",
         "title": "Name",
+        "type": "string"
+      },
+      "spec_version": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$",
+        "title": "Spec Version",
         "type": "string"
       },
       "description": {
@@ -7662,6 +8229,7 @@
     },
     "required": [
       "name",
+      "spec_version",
       "description",
       "input_schema",
       "output_schema",

--- a/tests/contract/test_event_store_contract.py
+++ b/tests/contract/test_event_store_contract.py
@@ -87,8 +87,10 @@ def test_store_rejects_duplicate_event_identity_globally(
     asyncio.run(exercise())
 
 
-def test_store_rejects_v2_terminal_evidence_for_a_different_request(
+@pytest.mark.parametrize("schema_version", (2, 3, 4))
+def test_store_rejects_versioned_terminal_evidence_for_a_different_request(
     store_factory: StoreFactory,
+    schema_version: int,
 ) -> None:
     async def exercise() -> None:
         store = await store_factory()
@@ -115,7 +117,7 @@ def test_store_rejects_v2_terminal_evidence_for_a_different_request(
                         request=requested,
                     )
                 ),
-                schema_version=2,
+                schema_version=schema_version,
             ),
             make_event(
                 run_id,
@@ -127,7 +129,7 @@ def test_store_rejects_v2_terminal_evidence_for_a_different_request(
                         tool_call_id=tool_call_id,
                     )
                 ),
-                schema_version=2,
+                schema_version=schema_version,
             ),
         )
         for event in initial:
@@ -162,7 +164,7 @@ def test_store_rejects_v2_terminal_evidence_for_a_different_request(
                     ),
                 )
             ),
-            schema_version=2,
+            schema_version=schema_version,
         )
 
         with pytest.raises(RunReducerError, match="does not match"):

--- a/tests/evals/test_p1_agent_loop_tasks.py
+++ b/tests/evals/test_p1_agent_loop_tasks.py
@@ -5,7 +5,7 @@ import shutil
 from pathlib import Path
 
 import pytest
-from tests.agent_loop_fixtures import TickingClock
+from tests.agent_loop_fixtures import TickingClock, run_fingerprint
 
 from bearagent.adapters.sqlite import SqliteEventStore
 from bearagent.adapters.testing import InMemoryEventStore, ScriptedFakeModelProvider
@@ -169,14 +169,19 @@ async def execute_task(
     tools = build_workspace_tools(workspace)
     registry = ToolRegistry(tools)
     provider = ScriptedFakeModelProvider(script_for(task))
+    allowed_tool_names = tuple(spec.name for spec in registry.specs)
     loop = AgentLoop(
         model_provider=provider,
         event_store=store,
         tool_executor=ToolExecutor(
             registry,
-            FixedToolPolicy(spec.name for spec in registry.specs),
+            FixedToolPolicy(allowed_tool_names),
         ),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(
+            registry.specs,
+            allowed_tool_names=allowed_tool_names,
+        ),
     )
     result = await loop.run(
         RunInput(

--- a/tests/integration/test_provider_selection_events.py
+++ b/tests/integration/test_provider_selection_events.py
@@ -5,6 +5,7 @@ from tests.agent_loop_fixtures import (
     TickingClock,
     agent_run_input,
     model_completed,
+    run_fingerprint,
     tool_executor,
 )
 
@@ -14,10 +15,10 @@ from bearagent.application.agent_loop import AgentLoop
 from bearagent.application.run_queries import RunQueryService
 from bearagent.domain.model import ModelFinishReason, ModelTextDelta
 from bearagent.domain.providers import ModelProtocol, ProviderSelection
-from bearagent.domain.run_events import RUN_EVENT_SCHEMA_VERSION_V3
+from bearagent.domain.run_events import RUN_EVENT_SCHEMA_VERSION_V4
 
 
-def test_sqlite_reopen_preserves_v3_provider_selection(tmp_path: Path) -> None:
+def test_sqlite_reopen_preserves_v4_provider_selection_and_fingerprint(tmp_path: Path) -> None:
     database_path = tmp_path / "events.sqlite3"
     selection = ProviderSelection(
         provider_id="primary",
@@ -42,6 +43,7 @@ def test_sqlite_reopen_preserves_v3_provider_selection(tmp_path: Path) -> None:
             tool_executor=tool_executor(),
             clock=TickingClock(),
             provider_selection=selection,
+            run_fingerprint=run_fingerprint(),
         ).run(agent_run_input())
 
         reopened = SqliteEventStore(database_path)
@@ -50,6 +52,7 @@ def test_sqlite_reopen_preserves_v3_provider_selection(tmp_path: Path) -> None:
         events = await reopened.list_events(result.run_id)
 
         assert inspection.provider_selection == selection
-        assert all(event.schema_version == RUN_EVENT_SCHEMA_VERSION_V3 for event in events)
+        assert inspection.run_fingerprint == run_fingerprint()
+        assert all(event.schema_version == RUN_EVENT_SCHEMA_VERSION_V4 for event in events)
 
     asyncio.run(exercise())

--- a/tests/recovery/crash_observability_child.py
+++ b/tests/recovery/crash_observability_child.py
@@ -1,0 +1,240 @@
+"""Child process that terminates at one committed P1 crash boundary."""
+
+import argparse
+import asyncio
+import os
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import NoReturn
+
+from bearagent.adapters.sqlite import SqliteEventStore
+from bearagent.adapters.tools.workspace_boundary import StagedWorkspaceOutput, WorkspaceBoundary
+from bearagent.adapters.tools.workspace_write import WorkspaceWriteTool
+from bearagent.application.agent_loop import AgentLoop
+from bearagent.domain.agent import AgentConfig, ModelPricing, RunInput
+from bearagent.domain.events import Event
+from bearagent.domain.ids import RunId, SessionId, ToolCallId
+from bearagent.domain.model import (
+    ModelCompleted,
+    ModelEvent,
+    ModelFinishReason,
+    ModelRequest,
+    ModelToolCall,
+    ModelUsage,
+)
+from bearagent.domain.runs import BudgetLimits, RunState
+from bearagent.runtime.fingerprints import build_run_fingerprint
+from bearagent.runtime.policy import FixedToolPolicy
+from bearagent.runtime.tool_executor import ToolExecutor
+from bearagent.runtime.tool_registry import ToolRegistry
+
+CRASH_EXIT_CODE = 91
+OUTPUT_PATH = "outputs/crash-evidence.txt"
+OUTPUT_CONTENT = "committed before process termination\n"
+
+
+class CrashAfterAppendStore:
+    """Delegate durability, then terminate after one selected commit returns."""
+
+    def __init__(
+        self,
+        inner: SqliteEventStore,
+        *,
+        event_type: str,
+        crash_marker: Path,
+    ) -> None:
+        self._inner = inner
+        self._event_type = event_type
+        self._crash_marker = crash_marker
+
+    async def append(self, event: Event) -> RunState:
+        state = await self._inner.append(event)
+        if event.event_type == self._event_type:
+            _crash(self._crash_marker, event.event_type)
+        return state
+
+    async def list_events(
+        self,
+        run_id: RunId,
+        *,
+        after_sequence: int = 0,
+        limit: int = 1_000,
+    ) -> tuple[Event, ...]:
+        return await self._inner.list_events(
+            run_id,
+            after_sequence=after_sequence,
+            limit=limit,
+        )
+
+    async def get_run(self, run_id: RunId) -> RunState | None:
+        return await self._inner.get_run(run_id)
+
+
+class CrashBeforeReplaceBoundary(WorkspaceBoundary):
+    """Terminate after staging but before the atomic target replacement."""
+
+    def __init__(self, root: Path, crash_marker: Path) -> None:
+        super().__init__(root)
+        self._crash_marker = crash_marker
+
+    def commit_output(self, staged: StagedWorkspaceOutput, *, deadline: float) -> None:
+        del staged, deadline
+        _crash(self._crash_marker, "before_replace")
+
+
+class CrashAfterReplaceBoundary(WorkspaceBoundary):
+    """Terminate immediately after the atomic target replacement returns."""
+
+    def __init__(self, root: Path, crash_marker: Path) -> None:
+        super().__init__(root)
+        self._crash_marker = crash_marker
+
+    def commit_output(self, staged: StagedWorkspaceOutput, *, deadline: float) -> None:
+        super().commit_output(staged, deadline=deadline)
+        _crash(self._crash_marker, "after_replace")
+
+
+class MarkerModelProvider:
+    """Emit one write request and record every externally observable invocation."""
+
+    def __init__(self, call_marker: Path) -> None:
+        self._call_marker = call_marker
+        self._tool_call_id = ToolCallId.new()
+
+    async def stream(self, request: ModelRequest) -> AsyncIterator[ModelEvent]:
+        del request
+        _append_durable_line(self._call_marker, "model_call")
+        yield ModelToolCall(
+            tool_call_id=self._tool_call_id,
+            provider_call_id="crash-observability-write",
+            name="workspace.write",
+            arguments={"path": OUTPUT_PATH, "content": OUTPUT_CONTENT},
+        )
+        yield ModelCompleted(
+            provider_request_id="crash-observability-response",
+            model="crash-test-model",
+            finish_reason=ModelFinishReason.TOOL_CALLS,
+            usage=ModelUsage(input_tokens=1, output_tokens=1),
+        )
+
+
+def _agent_config() -> AgentConfig:
+    return AgentConfig(
+        agent_id="crash-observability-agent",
+        agent_version="p1-v1",
+        instructions="Write the requested bounded output once.",
+        model="crash-test-model",
+        prompt_version="crash-prompt-v1",
+        context_version="crash-context-v1",
+        max_output_tokens=128,
+        model_timeout_ms=5_000,
+        max_context_chars=100_000,
+        max_tool_result_bytes=10_000,
+        tool_names=("workspace.write",),
+        pricing=ModelPricing(
+            version="crash-pricing-v1",
+            input_microusd_per_million_tokens=0,
+            output_microusd_per_million_tokens=0,
+        ),
+    )
+
+
+async def _run(args: argparse.Namespace) -> None:
+    workspace = Path(args.workspace)
+    await asyncio.to_thread(workspace.mkdir, parents=True, exist_ok=True)
+    database_path = Path(args.database)
+    crash_marker = Path(args.crash_marker)
+    model_calls = Path(args.model_calls)
+
+    if args.point == "k3_before_replace":
+        boundary: WorkspaceBoundary = CrashBeforeReplaceBoundary(workspace, crash_marker)
+    elif args.point == "k4_after_replace":
+        boundary = CrashAfterReplaceBoundary(workspace, crash_marker)
+    else:
+        boundary = WorkspaceBoundary(workspace)
+
+    tool = WorkspaceWriteTool(boundary)
+    registry = ToolRegistry((tool,))
+    policy = FixedToolPolicy((tool.spec.name,))
+    executor = ToolExecutor(registry, policy)
+    durable_store = SqliteEventStore(database_path)
+    await durable_store.initialize()
+    crash_event_types = {
+        "k1_after_tool_requested": "ToolCallRequested",
+        "k2_after_tool_started": "ToolCallStarted",
+        "k6_after_model_started": "ModelCallStarted",
+    }
+    event_type = crash_event_types.get(args.point)
+    store = (
+        durable_store
+        if event_type is None
+        else CrashAfterAppendStore(
+            durable_store,
+            event_type=event_type,
+            crash_marker=crash_marker,
+        )
+    )
+    loop = AgentLoop(
+        model_provider=MarkerModelProvider(model_calls),
+        event_store=store,
+        tool_executor=executor,
+        run_fingerprint=build_run_fingerprint(
+            bearagent_version="0.1.0+crash-test",
+            policy=policy.fingerprint,
+            tool_specs=registry.specs,
+        ),
+    )
+    await loop.run(
+        RunInput(
+            session_id=SessionId.new(),
+            objective="Write one crash-observability output.",
+            budget_limits=BudgetLimits(
+                max_model_iterations=2,
+                max_tokens=100,
+                max_cost_microusd=1_000,
+                max_wall_time_ms=30_000,
+                max_tool_calls=1,
+            ),
+            agent_config=_agent_config(),
+        ),
+        run_id=RunId.parse(args.run_id),
+    )
+    raise AssertionError("selected crash boundary was not reached")
+
+
+def _append_durable_line(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8", newline="\n") as handle:
+        handle.write(value + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _crash(marker: Path, value: str) -> NoReturn:
+    _append_durable_line(marker, value)
+    os._exit(CRASH_EXIT_CODE)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--point",
+        required=True,
+        choices=(
+            "k1_after_tool_requested",
+            "k2_after_tool_started",
+            "k3_before_replace",
+            "k4_after_replace",
+            "k6_after_model_started",
+        ),
+    )
+    parser.add_argument("--database", required=True)
+    parser.add_argument("--workspace", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--crash-marker", required=True)
+    parser.add_argument("--model-calls", required=True)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    asyncio.run(_run(_parse_args()))

--- a/tests/recovery/test_agent_loop_boundaries.py
+++ b/tests/recovery/test_agent_loop_boundaries.py
@@ -10,10 +10,12 @@ from tests.agent_loop_fixtures import (
     budget_limits,
     model_completed,
     read_tool_spec,
+    run_fingerprint,
     tool_executor,
 )
 
 from bearagent.adapters.testing import (
+    FakeModelProvider,
     FakeTool,
     InMemoryEventStore,
     ScriptedFakeModelProvider,
@@ -32,7 +34,14 @@ from bearagent.domain.model import (
     ModelTextDelta,
     ModelToolCall,
 )
-from bearagent.domain.runs import RunState
+from bearagent.domain.run_events import (
+    ModelCallFailedPayloadV2,
+    ToolCallFailedPayloadV2,
+    parse_run_event_payload,
+)
+from bearagent.domain.runs import RunState, RunStatus
+from bearagent.domain.tools import ToolRetrySafety
+from bearagent.ports.model import ModelProviderError
 from bearagent.ports.store import EventStoreError
 from bearagent.runtime.policy import FixedToolPolicy
 from bearagent.runtime.tool_executor import ToolExecutor
@@ -91,6 +100,7 @@ def loop_for(
         event_store=store,
         tool_executor=tool_executor(tool),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
 
 
@@ -179,6 +189,7 @@ def test_cancellation_propagates_and_keeps_last_committed_activity_non_terminal(
             event_store=store,
             tool_executor=tool_executor(),
             clock=TickingClock(),
+            run_fingerprint=run_fingerprint(),
         )
         task = asyncio.create_task(loop.run(agent_run_input()))
         await provider.started.wait()
@@ -284,6 +295,87 @@ def test_every_failure_terminal_append_boundary_stops_scheduling(failed_type: st
     assert store.attempted_types.count(failed_type) == 1
 
 
+def test_retryable_provider_failure_is_observed_once_without_automatic_retry() -> None:
+    failure = ErrorInfo(
+        category=ErrorCategory.PROVIDER,
+        code=ErrorCode.PROVIDER_UNAVAILABLE,
+        message="Provider is temporarily unavailable.",
+        retryable=True,
+    )
+    provider = FakeModelProvider((), failure=ModelProviderError(failure))
+    store = InMemoryEventStore()
+    loop = AgentLoop(
+        model_provider=provider,
+        event_store=store,
+        tool_executor=tool_executor(),
+        clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
+    )
+
+    result = asyncio.run(loop.run(agent_run_input()))
+    events = asyncio.run(store.list_events(result.run_id))
+    failed = parse_run_event_payload(
+        next(event for event in events if event.event_type == "ModelCallFailed")
+    )
+
+    assert result.state.status is RunStatus.FAILED
+    assert len(provider.requests) == 1
+    assert isinstance(failed, ModelCallFailedPayloadV2)
+    assert failed.error.retryable is True
+    assert tuple(event.event_type for event in events).count("ModelCallStarted") == 1
+
+
+def test_retryable_unsafe_tool_failure_does_not_repeat_the_tool_activity() -> None:
+    call_id = ToolCallId.new()
+    provider = ScriptedFakeModelProvider(
+        (
+            (
+                ModelToolCall(
+                    tool_call_id=call_id,
+                    provider_call_id="retryable-tool-failure",
+                    name="workspace.read",
+                    arguments={"path": "docs/index.md"},
+                ),
+                model_completed(ModelFinishReason.TOOL_CALLS),
+            ),
+            (
+                ModelTextDelta(text="The failed Tool was not retried automatically."),
+                model_completed(ModelFinishReason.STOP, request_id="after-tool-failure"),
+            ),
+        )
+    )
+    spec = read_tool_spec().model_copy(update={"retry_safety": ToolRetrySafety.NOT_SAFE})
+    tool = FakeTool(
+        spec,
+        failure=ErrorInfo(
+            category=ErrorCategory.TOOL,
+            code=ErrorCode.TOOL_TIMEOUT,
+            message="Tool timed out.",
+            retryable=True,
+        ),
+    )
+    store = InMemoryEventStore()
+    loop = AgentLoop(
+        model_provider=provider,
+        event_store=store,
+        tool_executor=tool_executor(tool),
+        clock=TickingClock(),
+        run_fingerprint=run_fingerprint((spec,)),
+    )
+
+    result = asyncio.run(loop.run(agent_run_input()))
+    events = asyncio.run(store.list_events(result.run_id))
+    failed = parse_run_event_payload(
+        next(event for event in events if event.event_type == "ToolCallFailed")
+    )
+
+    assert result.state.status is RunStatus.SUCCEEDED
+    assert len(tool.requests) == 1
+    assert isinstance(failed, ToolCallFailedPayloadV2)
+    assert failed.error.retryable is True
+    assert tuple(event.event_type for event in events).count("ToolCallStarted") == 1
+
+
 def test_real_workspace_write_is_not_retried_when_terminal_append_fails(
     tmp_path: Path,
 ) -> None:
@@ -322,6 +414,10 @@ def test_real_workspace_write_is_not_retried_when_terminal_append_fails(
             FixedToolPolicy(spec.name for spec in registry.specs),
         ),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(
+            registry.specs,
+            allowed_tool_names=tuple(spec.name for spec in registry.specs),
+        ),
     )
 
     with pytest.raises(EventStoreError):

--- a/tests/recovery/test_crash_observability.py
+++ b/tests/recovery/test_crash_observability.py
@@ -1,0 +1,231 @@
+import asyncio
+import sqlite3
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from tests.store_fixtures import make_event, payload_json, run_created_event
+
+from bearagent.adapters.sqlite import SqliteEventStore
+from bearagent.application.run_queries import RunQueryService
+from bearagent.domain.ids import ActivityId, ModelCallId, RunId
+from bearagent.domain.queries import RunInspection
+from bearagent.domain.run_events import ModelCallRequestedPayload, RunStartedPayload
+from bearagent.domain.runs import ActivityStatus, RunStatus
+from bearagent.interfaces.cli.contracts import InspectCommandOutput
+from bearagent.ports.store import EventStoreError
+
+REPOSITORY_ROOT = Path(__file__).parents[2]
+CHILD_PROCESS = Path(__file__).with_name("crash_observability_child.py")
+CRASH_EXIT_CODE = 91
+OUTPUT_RELATIVE_PATH = Path("outputs/crash-evidence.txt")
+OUTPUT_CONTENT = "committed before process termination\n"
+TERMINAL_EVENT_TYPES = frozenset({"RunSucceeded", "RunFailed"})
+
+
+@dataclass(frozen=True, slots=True)
+class CrashExpectation:
+    point: str
+    last_event_type: str
+    activity_status: ActivityStatus
+    crash_marker: str
+    model_calls: int
+    output_committed: bool
+
+
+CRASH_EXPECTATIONS = (
+    CrashExpectation(
+        point="k1_after_tool_requested",
+        last_event_type="ToolCallRequested",
+        activity_status=ActivityStatus.PENDING,
+        crash_marker="ToolCallRequested",
+        model_calls=1,
+        output_committed=False,
+    ),
+    CrashExpectation(
+        point="k2_after_tool_started",
+        last_event_type="ToolCallStarted",
+        activity_status=ActivityStatus.RUNNING,
+        crash_marker="ToolCallStarted",
+        model_calls=1,
+        output_committed=False,
+    ),
+    CrashExpectation(
+        point="k3_before_replace",
+        last_event_type="ToolCallStarted",
+        activity_status=ActivityStatus.RUNNING,
+        crash_marker="before_replace",
+        model_calls=1,
+        output_committed=False,
+    ),
+    CrashExpectation(
+        point="k4_after_replace",
+        last_event_type="ToolCallStarted",
+        activity_status=ActivityStatus.RUNNING,
+        crash_marker="after_replace",
+        model_calls=1,
+        output_committed=True,
+    ),
+    CrashExpectation(
+        point="k6_after_model_started",
+        last_event_type="ModelCallStarted",
+        activity_status=ActivityStatus.RUNNING,
+        crash_marker="ModelCallStarted",
+        model_calls=0,
+        output_committed=False,
+    ),
+)
+
+
+@pytest.mark.parametrize("expectation", CRASH_EXPECTATIONS, ids=lambda item: item.point)
+def test_committed_crash_boundary_is_visible_after_process_restart(
+    expectation: CrashExpectation,
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "events.sqlite3"
+    workspace = tmp_path / "workspace"
+    crash_marker = tmp_path / "crash.marker"
+    model_calls = tmp_path / "model.calls"
+    run_id = RunId.new()
+
+    child = subprocess.run(
+        (
+            sys.executable,
+            str(CHILD_PROCESS),
+            "--point",
+            expectation.point,
+            "--database",
+            str(database_path),
+            "--workspace",
+            str(workspace),
+            "--run-id",
+            str(run_id),
+            "--crash-marker",
+            str(crash_marker),
+            "--model-calls",
+            str(model_calls),
+        ),
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert child.returncode == CRASH_EXIT_CODE, child.stderr
+    assert crash_marker.read_text(encoding="utf-8").splitlines() == [expectation.crash_marker]
+    assert _line_count(model_calls) == expectation.model_calls
+
+    inspection, event_types = asyncio.run(_reopen(database_path, run_id))
+
+    assert inspection.state.status is RunStatus.RUNNING
+    assert event_types[-1] == expectation.last_event_type
+    assert not TERMINAL_EVENT_TYPES.intersection(event_types)
+    assert inspection.state.activities[-1].status is expectation.activity_status
+    assert inspection.artifacts == ()
+    assert inspection.run_fingerprint is not None
+
+    output_path = workspace / OUTPUT_RELATIVE_PATH
+    if expectation.output_committed:
+        assert output_path.read_text(encoding="utf-8") == OUTPUT_CONTENT
+    else:
+        assert not output_path.exists()
+    if expectation.point == "k3_before_replace":
+        assert tuple((workspace / "outputs").glob(".bearagent-*.tmp"))
+
+    calls_before_cli = _line_count(model_calls)
+    cli_result = _inspect_with_cli(database_path, run_id)
+
+    assert cli_result.result.state.status is RunStatus.RUNNING
+    assert cli_result.result.state.last_sequence == len(event_types)
+    assert _line_count(model_calls) == calls_before_cli
+
+
+def test_k5_projection_failure_rolls_back_event_and_projection_together(tmp_path: Path) -> None:
+    database_path = tmp_path / "events.sqlite3"
+    run_id = RunId.new()
+    created = run_created_event(run_id)
+    started = make_event(run_id, 2, "RunStarted", payload_json(RunStartedPayload()))
+    requested = make_event(
+        run_id,
+        3,
+        "ModelCallRequested",
+        payload_json(
+            ModelCallRequestedPayload(
+                activity_id=ActivityId.new(),
+                model_call_id=ModelCallId.new(),
+            )
+        ),
+    )
+
+    async def inject_failure() -> None:
+        store = SqliteEventStore(database_path)
+        await store.initialize()
+        await store.append(created)
+        await store.append(started)
+        with sqlite3.connect(database_path) as connection:
+            connection.execute(
+                """
+                CREATE TRIGGER reject_pending_activity
+                BEFORE INSERT ON activity_projections
+                WHEN NEW.status = 'pending'
+                BEGIN
+                    SELECT RAISE(ABORT, 'injected projection failure');
+                END
+                """
+            )
+        with pytest.raises(EventStoreError, match="projection update failed"):
+            await store.append(requested)
+
+    asyncio.run(inject_failure())
+    inspection, event_types = asyncio.run(_reopen(database_path, run_id))
+
+    assert event_types == ("RunCreated", "RunStarted")
+    assert inspection.state.status is RunStatus.RUNNING
+    assert inspection.state.last_sequence == 2
+    assert inspection.state.activities == ()
+
+    cli_result = _inspect_with_cli(database_path, run_id)
+    assert cli_result.result.state.last_sequence == 2
+
+
+async def _reopen(
+    database_path: Path,
+    run_id: RunId,
+) -> tuple[RunInspection, tuple[str, ...]]:
+    store = SqliteEventStore(database_path)
+    await store.initialize()
+    events = await store.list_events(run_id)
+    inspection = await RunQueryService(store).inspect(run_id)
+    return inspection, tuple(event.event_type for event in events)
+
+
+def _inspect_with_cli(database_path: Path, run_id: RunId) -> InspectCommandOutput:
+    completed = subprocess.run(
+        (
+            sys.executable,
+            "-m",
+            "bearagent",
+            "run",
+            "inspect",
+            str(run_id),
+            "--database",
+            str(database_path),
+            "--json",
+        ),
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return InspectCommandOutput.model_validate_json(completed.stdout)
+
+
+def _line_count(path: Path) -> int:
+    if not path.exists():
+        return 0
+    return len(path.read_text(encoding="utf-8").splitlines())

--- a/tests/security/test_agent_loop.py
+++ b/tests/security/test_agent_loop.py
@@ -5,6 +5,7 @@ from tests.agent_loop_fixtures import (
     agent_run_input,
     model_completed,
     read_tool_spec,
+    run_fingerprint,
     tool_executor,
 )
 
@@ -35,6 +36,7 @@ def test_raw_provider_exception_is_not_persisted_or_returned() -> None:
         event_store=store,
         tool_executor=tool_executor(),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
 
     result = asyncio.run(loop.run(agent_run_input()))
@@ -75,6 +77,7 @@ def test_model_cannot_expand_exposed_tools_or_bypass_executor_policy() -> None:
             FixedToolPolicy(),
         ),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(allowed_tool_names=()),
     )
 
     result = asyncio.run(loop.run(agent_run_input()))

--- a/tests/security/test_run_events.py
+++ b/tests/security/test_run_events.py
@@ -16,6 +16,7 @@ from bearagent.domain.ids import (
     SessionId,
     ToolCallId,
 )
+from bearagent.domain.run_events import LATEST_RUN_EVENT_SCHEMA_VERSION
 from bearagent.runtime.reducer import RunReducerError, reduce_event
 
 BASE_TIME = datetime(2026, 8, 11, 8, 0, tzinfo=UTC)
@@ -131,7 +132,7 @@ def test_unknown_event_type_and_schema_version_fail_closed() -> None:
             "activity_id": str(ActivityId.new()),
             "model_call_id": str(ModelCallId.new()),
         },
-        schema_version=4,
+        schema_version=LATEST_RUN_EVENT_SCHEMA_VERSION + 1,
     )
     with pytest.raises(RunReducerError, match="Unsupported") as caught_version:
         reduce_event(state, unknown_version)

--- a/tests/tool_fixtures.py
+++ b/tests/tool_fixtures.py
@@ -21,6 +21,7 @@ def build_tool_spec(
 ) -> ToolSpec:
     return ToolSpec(
         name=name,
+        spec_version="1",
         description="Read one test resource.",
         input_schema={
             "type": "object",

--- a/tests/unit/test_agent_loop.py
+++ b/tests/unit/test_agent_loop.py
@@ -2,6 +2,7 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from tests.agent_loop_fixtures import run_fingerprint
 
 from bearagent.adapters.testing import (
     FakeTool,
@@ -43,6 +44,7 @@ class TickingClock:
 def tool_spec() -> ToolSpec:
     return ToolSpec(
         name="workspace.read",
+        spec_version="1",
         description="Read one workspace text file.",
         input_schema={
             "type": "object",
@@ -131,6 +133,7 @@ def test_agent_loop_persists_a_text_run_and_deterministic_cost() -> None:
         event_store=store,
         tool_executor=executor(),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
 
     result = asyncio.run(loop.run(run_input()))
@@ -147,7 +150,7 @@ def test_agent_loop_persists_a_text_run_and_deterministic_cost() -> None:
         "ModelCallCompleted",
         "RunSucceeded",
     )
-    assert all(event.schema_version == 2 for event in events)
+    assert all(event.schema_version == 4 for event in events)
     requested = parse_run_event_payload(events[2])
     assert requested.request == provider.requests[0]  # type: ignore[union-attr]
 
@@ -162,6 +165,7 @@ def test_agent_loop_accepts_a_trusted_preallocated_run_id() -> None:
         event_store=store,
         tool_executor=executor(),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
     run_id = RunId.new()
 
@@ -202,6 +206,7 @@ def test_agent_loop_executes_tool_then_rebuilds_context_for_final_answer() -> No
         event_store=store,
         tool_executor=executor(tool),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
 
     result = asyncio.run(loop.run(run_input()))
@@ -268,6 +273,7 @@ def test_agent_loop_executes_multiple_model_tool_calls_in_returned_order() -> No
         event_store=InMemoryEventStore(),
         tool_executor=executor(tool),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
 
     result = asyncio.run(loop.run(run_input()))
@@ -322,6 +328,7 @@ def test_agent_loop_returns_structured_tool_failure_to_the_model() -> None:
         event_store=store,
         tool_executor=executor(tool),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
 
     result = asyncio.run(loop.run(run_input()))
@@ -343,6 +350,7 @@ def test_agent_loop_fails_on_budget_before_calling_provider() -> None:
         event_store=store,
         tool_executor=executor(),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
 
     result = asyncio.run(loop.run(run_input(max_model_iterations=0)))
@@ -367,6 +375,7 @@ def test_agent_loop_rejects_unregistered_configured_tool_before_creating_run() -
         event_store=store,
         tool_executor=executor(),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
     invalid_config = AgentConfig.model_validate(
         {**config().model_dump(), "tool_names": ("workspace.write",)}
@@ -392,6 +401,7 @@ def test_agent_loop_discards_partial_output_on_protocol_failure() -> None:
         event_store=store,
         tool_executor=executor(),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
 
     result = asyncio.run(loop.run(run_input()))
@@ -429,6 +439,7 @@ def test_agent_loop_does_not_pretend_missing_provider_usage_is_zero() -> None:
         event_store=store,
         tool_executor=executor(),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
 
     result = asyncio.run(loop.run(run_input()))
@@ -460,6 +471,7 @@ def test_agent_loop_rejects_oversized_tool_arguments_before_model_completion() -
         event_store=store,
         tool_executor=executor(),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
 
     result = asyncio.run(loop.run(run_input()))
@@ -498,6 +510,7 @@ def test_agent_loop_rejects_duplicate_provider_tool_call_identity() -> None:
         event_store=store,
         tool_executor=executor(),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
 
     result = asyncio.run(loop.run(run_input()))
@@ -540,6 +553,7 @@ def test_agent_loop_rejects_provider_tool_call_identity_reused_across_rounds() -
         event_store=store,
         tool_executor=executor(tool),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
 
     result = asyncio.run(loop.run(run_input()))
@@ -571,6 +585,7 @@ def test_agent_loop_fails_safely_when_model_request_event_exceeds_node_limit() -
         event_store=store,
         tool_executor=executor(tool),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint((large_schema_spec,)),
     )
 
     result = asyncio.run(loop.run(run_input()))
@@ -611,6 +626,7 @@ def test_agent_loop_fails_safely_when_model_request_event_exceeds_byte_limit() -
         event_store=store,
         tool_executor=executor(tool),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint((large_schema_spec,)),
     )
     large_input = RunInput(
         session_id=SessionId.new(),
@@ -663,6 +679,7 @@ def test_agent_loop_compacts_unpersistable_tool_execution_evidence() -> None:
         event_store=store,
         tool_executor=executor(tool),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint((large_spec,)),
     )
 
     result = asyncio.run(loop.run(run_input()))
@@ -702,6 +719,7 @@ def test_agent_loop_rejects_model_completion_that_cannot_fit_an_event() -> None:
         event_store=store,
         tool_executor=executor(),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
 
     result = asyncio.run(loop.run(run_input()))
@@ -743,6 +761,7 @@ def test_agent_loop_records_maximum_valid_single_call_cost() -> None:
         event_store=InMemoryEventStore(),
         tool_executor=executor(),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
     high_input = RunInput(
         session_id=SessionId.new(),
@@ -791,6 +810,7 @@ def test_agent_loop_records_one_call_token_overshoot_before_stopping() -> None:
         event_store=InMemoryEventStore(),
         tool_executor=executor(),
         clock=TickingClock(),
+        run_fingerprint=run_fingerprint(),
     )
 
     result = asyncio.run(

--- a/tests/unit/test_context_builder.py
+++ b/tests/unit/test_context_builder.py
@@ -114,6 +114,7 @@ def initial_events(agent_config: AgentConfig | None = None) -> tuple[Event, ...]
 def tool_spec(name: str) -> ToolSpec:
     return ToolSpec(
         name=name,
+        spec_version="1",
         description=f"Execute {name} safely.",
         input_schema={"type": "object", "properties": {"path": {"type": "string"}}},
         output_schema={"type": "object"},
@@ -364,6 +365,7 @@ def test_context_wraps_combined_tool_schema_overflow_as_a_safe_error() -> None:
     large_specs = tuple(
         ToolSpec(
             name=f"workspace.tool{index}",
+            spec_version="1",
             description="One large test schema.",
             input_schema={"type": "object", "description": "x" * 850_000},
             output_schema={"type": "object"},

--- a/tests/unit/test_provider_composition.py
+++ b/tests/unit/test_provider_composition.py
@@ -106,12 +106,17 @@ def test_v2_composition_records_selected_provider_without_reading_key_when_injec
     )
     result = asyncio.run(services.agent_loop.run(agent_run_input()))
     inspection = asyncio.run(services.queries.inspect(result.run_id))
+    events = asyncio.run(services.queries.events(result.run_id))
 
     assert inspection.provider_selection is not None
     assert inspection.provider_selection.provider_id == "primary"
     configured_provider = ProviderCatalog.model_validate(catalog_data()).providers[0]
     assert inspection.provider_selection.config_version == configured_provider.configuration_version
     assert inspection.provider_selection.protocol is ModelProtocol.OPENAI_RESPONSES
+    assert inspection.run_fingerprint is not None
+    assert tuple(tool.name for tool in inspection.run_fingerprint.tools) == ("workspace.read",)
+    assert "test-provider-secret" not in inspection.model_dump_json()
+    assert all("test-provider-secret" not in event.model_dump_json() for event in events.events)
     assert services.agent_config.model == "test-model"
     assert services.agent_config.pricing.version == "unpriced"
 

--- a/tests/unit/test_provider_selection_events.py
+++ b/tests/unit/test_provider_selection_events.py
@@ -4,18 +4,22 @@ import pytest
 from pydantic import ValidationError
 from tests.agent_loop_fixtures import (
     TickingClock,
+    agent_config,
     agent_run_input,
+    budget_limits,
     model_completed,
     read_tool_spec,
+    run_fingerprint,
     tool_executor,
 )
+from tests.store_fixtures import make_event, payload_json
 
 from bearagent.adapters.testing import FakeTool, InMemoryEventStore, ScriptedFakeModelProvider
 from bearagent.application.agent_loop import AgentLoop
 from bearagent.application.run_queries import RunQueryService
 from bearagent.domain.agent import RunResult
 from bearagent.domain.events import Event
-from bearagent.domain.ids import ToolCallId
+from bearagent.domain.ids import RunId, SessionId, ToolCallId
 from bearagent.domain.model import (
     ModelFinishReason,
     ModelTextDelta,
@@ -24,8 +28,9 @@ from bearagent.domain.model import (
 from bearagent.domain.providers import ModelProtocol, ProviderSelection
 from bearagent.domain.queries import RunInspection
 from bearagent.domain.run_events import (
-    RUN_EVENT_SCHEMA_VERSION_V3,
+    RUN_EVENT_SCHEMA_VERSION_V4,
     RunCreatedPayloadV3,
+    RunCreatedPayloadV4,
     parse_run_event_payload,
 )
 from bearagent.interfaces.cli.renderers import render_inspection
@@ -56,7 +61,7 @@ def test_provider_selection_is_strict_and_contains_no_connection_fields() -> Non
         )
 
 
-def test_v3_run_reuses_agent_loop_reducer_context_and_query_paths() -> None:
+def test_v4_run_reuses_agent_loop_reducer_context_and_query_paths() -> None:
     tool_call_id = ToolCallId.new()
     provider = ScriptedFakeModelProvider(
         (
@@ -83,6 +88,7 @@ def test_v3_run_reuses_agent_loop_reducer_context_and_query_paths() -> None:
         tool_executor=tool_executor(tool),
         clock=TickingClock(),
         provider_selection=provider_selection(),
+        run_fingerprint=run_fingerprint(),
     )
 
     async def exercise() -> tuple[RunResult, tuple[Event, ...], RunInspection]:
@@ -97,14 +103,46 @@ def test_v3_run_reuses_agent_loop_reducer_context_and_query_paths() -> None:
     assert len(provider.requests) == 2
     assert len(tool.requests) == 1
     assert events
-    assert all(event.schema_version == RUN_EVENT_SCHEMA_VERSION_V3 for event in events)
+    assert all(event.schema_version == RUN_EVENT_SCHEMA_VERSION_V4 for event in events)
     parsed = tuple(parse_run_event_payload(event) for event in events)
-    assert isinstance(parsed[0], RunCreatedPayloadV3)
+    assert isinstance(parsed[0], RunCreatedPayloadV4)
     assert parsed[0].provider_selection == provider_selection()
     assert inspection.provider_selection == provider_selection()
+    assert inspection.run_fingerprint == run_fingerprint()
 
     rendered = render_inspection(inspection)
     assert "Provider ID: primary" in rendered
     assert "Provider protocol: openai_responses" in rendered
+    assert "BearAgent version: 0.1.0+test" in rendered
+    assert "Tool contract: workspace.read 1 sha256=" in rendered
     assert "base_url" not in rendered
     assert "API_KEY" not in rendered
+
+
+def test_query_keeps_v3_provider_selection_read_compatibility() -> None:
+    run_id = RunId.new()
+    legacy = make_event(
+        run_id,
+        1,
+        "RunCreated",
+        payload_json(
+            RunCreatedPayloadV3(
+                session_id=SessionId.new(),
+                budget_limits=budget_limits(),
+                objective="Read a legacy Run.",
+                agent_config=agent_config(),
+                provider_selection=provider_selection(),
+            )
+        ),
+        schema_version=3,
+    )
+
+    async def exercise() -> RunInspection:
+        store = InMemoryEventStore()
+        await store.append(legacy)
+        return await RunQueryService(store).inspect(run_id)
+
+    inspection = asyncio.run(exercise())
+
+    assert inspection.provider_selection == provider_selection()
+    assert inspection.run_fingerprint is None

--- a/tests/unit/test_run_fingerprints.py
+++ b/tests/unit/test_run_fingerprints.py
@@ -1,0 +1,103 @@
+import pytest
+from pydantic import JsonValue, ValidationError
+from tests.tool_fixtures import build_tool_spec
+
+from bearagent.domain.fingerprints import (
+    PolicyFingerprint,
+    RunFingerprint,
+    ToolFingerprint,
+)
+from bearagent.runtime.fingerprints import (
+    build_run_fingerprint,
+    canonical_sha256,
+    tool_fingerprint,
+)
+from bearagent.runtime.policy import FixedToolPolicy
+
+
+def test_canonical_sha256_ignores_mapping_insertion_order() -> None:
+    first: dict[str, JsonValue] = {"name": "workspace.read", "version": "1"}
+    second: dict[str, JsonValue] = {"version": "1", "name": "workspace.read"}
+
+    assert canonical_sha256(first) == canonical_sha256(second)
+
+
+def test_fixed_policy_fingerprint_is_stable_for_allowlist_order() -> None:
+    first = FixedToolPolicy(["workspace.read", "workspace.list"])
+    second = FixedToolPolicy(["workspace.list", "workspace.read"])
+
+    assert first.fingerprint == second.fingerprint
+    assert first.fingerprint != FixedToolPolicy(["workspace.read"]).fingerprint
+
+
+def test_run_fingerprint_sorts_tools_and_detects_contract_changes() -> None:
+    read = build_tool_spec(name="workspace.read")
+    listed = build_tool_spec(name="workspace.list")
+    policy = FixedToolPolicy([read.name, listed.name])
+
+    first = build_run_fingerprint(
+        bearagent_version="0.1.0+test",
+        policy=policy.fingerprint,
+        tool_specs=[read, listed],
+    )
+    second = build_run_fingerprint(
+        bearagent_version="0.1.0+test",
+        policy=policy.fingerprint,
+        tool_specs=[listed, read],
+    )
+
+    changed = read.model_copy(update={"spec_version": "2"})
+
+    assert first == second
+    assert tuple(tool.name for tool in first.tools) == ("workspace.list", "workspace.read")
+    assert tool_fingerprint(read) != tool_fingerprint(changed)
+
+
+def test_run_fingerprint_rejects_duplicate_or_unsorted_tools() -> None:
+    policy = PolicyFingerprint(version="policy-v1", sha256="a" * 64)
+    read = ToolFingerprint(
+        name="workspace.read",
+        spec_version="1",
+        sha256="b" * 64,
+    )
+    listed = ToolFingerprint(
+        name="workspace.list",
+        spec_version="1",
+        sha256="c" * 64,
+    )
+
+    with pytest.raises(ValidationError, match="sorted by name"):
+        RunFingerprint(
+            bearagent_version="0.1.0",
+            policy=policy,
+            tools=(read, listed),
+        )
+    with pytest.raises(ValidationError, match="must be unique"):
+        RunFingerprint(
+            bearagent_version="0.1.0",
+            policy=policy,
+            tools=(read, read),
+        )
+
+
+def test_fingerprint_rejects_non_sha256_text() -> None:
+    with pytest.raises(ValidationError):
+        PolicyFingerprint(version="policy-v1", sha256="not-a-sha256")
+
+
+def test_run_fingerprint_rejects_configuration_and_authority_fields() -> None:
+    valid = build_run_fingerprint(
+        bearagent_version="0.1.0+test",
+        policy=FixedToolPolicy(["workspace.read"]).fingerprint,
+        tool_specs=(build_tool_spec(),),
+    ).model_dump(mode="json")
+
+    with pytest.raises(ValidationError):
+        RunFingerprint.model_validate(
+            {
+                **valid,
+                "workspace_path": "C:/private/workspace",
+                "api_key": "must-not-be-stored",
+                "grant": {"tool": "workspace.write"},
+            }
+        )

--- a/tests/unit/test_run_reducer.py
+++ b/tests/unit/test_run_reducer.py
@@ -110,7 +110,10 @@ def tool_error() -> ErrorInfo:
     )
 
 
-def test_v2_tool_terminal_requires_the_exact_requested_tool_request() -> None:
+@pytest.mark.parametrize("schema_version", (2, 3, 4))
+def test_versioned_tool_terminal_requires_the_exact_requested_tool_request(
+    schema_version: int,
+) -> None:
     run_id, _, events = started_run_events()
     state = reduce_events(events)
     activity_id = ActivityId.new()
@@ -130,7 +133,7 @@ def test_v2_tool_terminal_requires_the_exact_requested_tool_request() -> None:
             tool_name=requested.name,
             request=requested,
         ),
-        schema_version=2,
+        schema_version=schema_version,
     )
     state = reduce_event(state, requested_event)
     started_event = make_event(
@@ -138,7 +141,7 @@ def test_v2_tool_terminal_requires_the_exact_requested_tool_request() -> None:
         4,
         "ToolCallStarted",
         ToolCallStartedPayload(activity_id=activity_id, tool_call_id=tool_call_id),
-        schema_version=2,
+        schema_version=schema_version,
     )
     state = reduce_event(state, started_event)
     error = tool_error()
@@ -165,7 +168,7 @@ def test_v2_tool_terminal_requires_the_exact_requested_tool_request() -> None:
                 ),
             ),
         ),
-        schema_version=2,
+        schema_version=schema_version,
     )
 
     with pytest.raises(RunReducerError, match="does not match"):

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -4,7 +4,7 @@ from typing import cast
 import pytest
 from tests.tool_fixtures import build_tool_spec
 
-from bearagent.domain.tools import ToolSideEffect
+from bearagent.domain.tools import ToolSideEffect, ToolSpec
 from bearagent.ports.tools import Tool
 from bearagent.runtime.tool_registry import ToolRegistry
 
@@ -51,5 +51,27 @@ def test_registry_snapshots_trusted_spec_before_tool_can_replace_it() -> None:
     tool.spec = build_tool_spec(name="danger.run", side_effect=ToolSideEffect.READ_ONLY)
 
     registered_spec = registry.get_spec("danger.run")
+    assert registered_spec is not None
+    assert registered_spec.side_effect is ToolSideEffect.CODE_EXECUTION
+
+
+def test_registry_reads_each_tool_spec_once_when_building_the_snapshot() -> None:
+    class ChangingSpecTool:
+        def __init__(self) -> None:
+            self.reads = 0
+
+        @property
+        def spec(self) -> ToolSpec:
+            self.reads += 1
+            side_effect = (
+                ToolSideEffect.CODE_EXECUTION if self.reads == 1 else ToolSideEffect.READ_ONLY
+            )
+            return build_tool_spec(name="danger.run", side_effect=side_effect)
+
+    concrete_tool = ChangingSpecTool()
+    registry = ToolRegistry([cast(Tool, concrete_tool)])
+
+    registered_spec = registry.get_spec("danger.run")
+    assert concrete_tool.reads == 1
     assert registered_spec is not None
     assert registered_spec.side_effect is ToolSideEffect.CODE_EXECUTION


### PR DESCRIPTION
## Summary

- Persist trusted BearAgent, Provider, Policy, and Tool contract identity in new RunCreated v4 Events while preserving v1-v3 reads.
- Record committed crash-boundary facts and expose them through existing inspect/events paths without adding automatic recovery or retry authority.
- Harden Tool execution evidence validation across schema v2-v4, snapshot each ToolSpec once, and remove unused placeholder/error-detail code found by the closing audit.

## Change governance

- Classification: `S2`
- Feature Spec: `F-0018`
- ADR: `ADR-0016`
- Plan: `PLAN-F-0018`

## Validation

- [x] Relevant unit, contract, integration, crash/recovery-boundary, and security tests; full suite: 481 passed
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pyright`
- [x] `uv run pytest`
- [x] `uv run python scripts/check_docs.py` (140 Markdown files)
- [x] `uv run python scripts/check_governance.py` (13 Specs, 12 Plans, 16 ADRs)
- [x] `npm run build --prefix=site` (45 pages)

## Documentation impact

- Engineering `docs/`: `docs/specs/F-0018-p1-evidence-hardening.md`, `docs/adr/ADR-0016-run-contract-fingerprint-committed-crash-facts.md`, `docs/plans/PLAN-F-0018-p1-evidence-hardening.md`, `docs/architecture/overview.md`, `docs/project/roadmap.md`
- Site beginner learning path: `site/src/content/docs/zh-cn/learn/run-inspect-events.md`, `site/src/content/docs/zh-cn/learn/recovery-authority-isolation.md`
- Site developer documentation: `site/src/content/docs/zh-cn/development/agent-loop.md`, `site/src/content/docs/zh-cn/development/run-reducer-and-budgets.md`, `site/src/content/docs/zh-cn/development/sqlite-event-store.md`, `site/src/content/docs/zh-cn/development/tool-execution-boundary.md`
- Site current status or milestone summary: `site/src/content/docs/zh-cn/project/status.md`, `site/src/content/docs/zh-cn/project/milestones.md`
- Generated reference: `N/A - compatibility snapshots already cover the versioned Event schemas and remain unchanged`

- [x] Every surface above has either an updated path or a concrete `N/A` reason
- [x] Content distinguishes committed facts from P2 recovery and P3 authorization
- [x] Changed prose was read in context
- [x] No external project capability is presented as current BearAgent behavior
